### PR TITLE
Add tooltip for overlay prompt summary

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1383,12 +1383,15 @@
 	                        </Grid.ColumnDefinitions>
 
 	                        <!-- Panel 1: prompt (wrap to two lines) -->
-	                        <Button Grid.Column="0" Background="Transparent" BorderThickness="0" Padding="0"
-	                                Command="{Binding ToggleOverlayDetailsCommand}">
-	                            <TextBlock Foreground="#FFF" FontSize="13" TextWrapping="Wrap" MaxLines="2"
-	                                       TextTrimming="CharacterEllipsis"
-	                                       Text="{Binding OverlaySelectedItem.PromptShort}"/>
-	                        </Button>
+                                <Button Grid.Column="0" Background="Transparent" BorderThickness="0" Padding="0"
+                                        Command="{Binding ToggleOverlayDetailsCommand}">
+                                    <!-- WPF TextBlock lacks MaxLines; cap at ~2 lines via line height/max height. -->
+                                    <TextBlock Foreground="#FFF" FontSize="13" TextWrapping="Wrap"
+                                               LineStackingStrategy="BlockLineHeight" LineHeight="16" MaxHeight="32"
+                                               TextTrimming="CharacterEllipsis"
+                                               Text="{Binding OverlaySelectedItem.PromptShort}"
+                                               ToolTip="{Binding OverlaySelectedItem.Prompt}"/>
+                                </Button>
 
 	                        <!-- Panel 2: model / steps / cfg -->
 	                        <StackPanel Grid.Column="1" Margin="12,0,0,0" VerticalAlignment="Center">


### PR DESCRIPTION
## Summary
- show the full overlay prompt in a tooltip while keeping the two-line capped display

## Testing
- dotnet build *(fails: dotnet CLI not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc57fb32c83279a0947ddd3e4d437)