### PR TITLE
Fix build errors for imaging and autosave helper

### DIFF
--- a/Controls/ZoomPanImage.xaml.cs
+++ b/Controls/ZoomPanImage.xaml.cs
@@ -1,4 +1,8 @@
 /*
+FIX: build error CS0246 (BitmapSource missing) when computing click-outside detection.
+CAUSE: Imaging namespace was not imported in the code-behind.
+CHANGE: Add System.Windows.Media.Imaging using so BitmapSource resolves. 2026-03-02
+
 FIX: Image overlay needed zoom + pan without closing the overlay when clicking on the image.
 CAUSE: Previous overlay used a Button wrapping the Image, so any click closed it and there was no zoom/pan.
 CHANGE: Added ZoomPanImage UserControl with wheel-zoom + drag-pan + double-click reset. 2025-12-24
@@ -9,6 +13,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace PromptLoom.Controls;
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,3 +1,5 @@
+// FIX: build error CS0103 (AutoSave missing) when randomizing categories/subcategories | CAUSE: refactor removed helper used in event handlers
+// CHANGE: reintroduce AutoSave helper to funnel into debounced queue | DATE: 2026-03-02
 // FIX: build error CS1039 (Unterminated string literal) in TestSwarmConnection | CAUSE: multiline interpolated string split across lines
 // CHANGE: keep the string on one source line using \n escape | DATE: 2025-12-22
 // FIX: build error CS0103 (missing TryParseSwarmWsFrame symbol) | CAUSE: parser helper exists as SwarmWsParser.TryParseSwarmWsFrame but was called unqualified
@@ -944,6 +946,11 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
         }
 
         Run();
+    }
+
+    private void AutoSave()
+    {
+        QueueAutoSave();
     }
 
     private void QueueAutoSave()


### PR DESCRIPTION
## Summary
- add the missing imaging namespace so BitmapSource resolves in the zoom/pan control
- restore an AutoSave helper that routes randomization actions into the existing debounced save path

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ccdfa30988327834c811ba388ba6d)