### PR TITLE
Add SwarmUI service seam and async commands

### DIFF
--- a/PromptLoom.Tests/Fakes/FakeFileSystem.cs
+++ b/PromptLoom.Tests/Fakes/FakeFileSystem.cs
@@ -36,13 +36,56 @@ public sealed class FakeFileSystem : IFileSystem
 
     public string ReadAllText(string path) => _files[path];
 
+    public string[] ReadAllLines(string path)
+        => _files.TryGetValue(path, out var contents)
+            ? contents.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
+            : [];
+
     public void WriteAllText(string path, string contents)
     {
         AddFile(path, contents);
     }
 
+    public void AppendAllText(string path, string contents)
+    {
+        if (_files.TryGetValue(path, out var existing))
+            _files[path] = existing + contents;
+        else
+            AddFile(path, contents);
+    }
+
+    public void DeleteFile(string path)
+    {
+        _files.Remove(path);
+    }
+
+    public void DeleteDirectory(string path, bool recursive)
+    {
+        if (recursive)
+        {
+            var toRemove = _files.Keys.Where(f => f.StartsWith(path, StringComparison.OrdinalIgnoreCase)).ToList();
+            foreach (var f in toRemove) _files.Remove(f);
+            var dirRemove = _directories.Where(d => d.StartsWith(path, StringComparison.OrdinalIgnoreCase)).ToList();
+            foreach (var d in dirRemove) _directories.Remove(d);
+        }
+        else
+        {
+            _directories.Remove(path);
+        }
+    }
+
+    public void CopyFile(string sourceFileName, string destFileName, bool overwrite)
+    {
+        if (!_files.TryGetValue(sourceFileName, out var contents)) return;
+        if (!overwrite && _files.ContainsKey(destFileName)) return;
+        AddFile(destFileName, contents);
+    }
+
     public IEnumerable<string> GetDirectories(string path)
         => _directories.Where(d => d.StartsWith(path, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    public IEnumerable<string> EnumerateDirectories(string path)
+        => GetDirectories(path);
 
     public IEnumerable<string> GetFiles(string path, string searchPattern, SearchOption searchOption)
         => _files.Keys.Where(f => f.StartsWith(path, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -52,4 +95,6 @@ public sealed class FakeFileSystem : IFileSystem
 
     public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
         => GetFiles(path, searchPattern, searchOption);
+
+    public string? GetParentDirectory(string path) => Path.GetDirectoryName(path);
 }

--- a/Services/FileSystem.cs
+++ b/Services/FileSystem.cs
@@ -33,14 +33,44 @@ public interface IFileSystem
     string ReadAllText(string path);
 
     /// <summary>
+    /// Reads all lines from a file.
+    /// </summary>
+    string[] ReadAllLines(string path);
+
+    /// <summary>
     /// Writes all text to a file, creating it if needed.
     /// </summary>
     void WriteAllText(string path, string contents);
 
     /// <summary>
+    /// Appends text to a file, creating it if needed.
+    /// </summary>
+    void AppendAllText(string path, string contents);
+
+    /// <summary>
+    /// Deletes a file if it exists.
+    /// </summary>
+    void DeleteFile(string path);
+
+    /// <summary>
+    /// Deletes a directory.
+    /// </summary>
+    void DeleteDirectory(string path, bool recursive);
+
+    /// <summary>
+    /// Copies a file.
+    /// </summary>
+    void CopyFile(string sourceFileName, string destFileName, bool overwrite);
+
+    /// <summary>
     /// Returns subdirectories within the specified directory.
     /// </summary>
     IEnumerable<string> GetDirectories(string path);
+
+    /// <summary>
+    /// Enumerates subdirectories within the specified directory.
+    /// </summary>
+    IEnumerable<string> EnumerateDirectories(string path);
 
     /// <summary>
     /// Returns files matching the search pattern.
@@ -56,6 +86,11 @@ public interface IFileSystem
     /// Enumerates files matching the search pattern.
     /// </summary>
     IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
+
+    /// <summary>
+    /// Returns the parent directory path, or null if none.
+    /// </summary>
+    string? GetParentDirectory(string path);
 }
 
 /// <summary>
@@ -76,10 +111,33 @@ public sealed class FileSystem : IFileSystem
     public string ReadAllText(string path) => File.ReadAllText(path);
 
     /// <inheritdoc/>
+    public string[] ReadAllLines(string path) => File.ReadAllLines(path);
+
+    /// <inheritdoc/>
     public void WriteAllText(string path, string contents) => File.WriteAllText(path, contents);
 
     /// <inheritdoc/>
+    public void AppendAllText(string path, string contents) => File.AppendAllText(path, contents);
+
+    /// <inheritdoc/>
+    public void DeleteFile(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    /// <inheritdoc/>
+    public void DeleteDirectory(string path, bool recursive) => Directory.Delete(path, recursive);
+
+    /// <inheritdoc/>
+    public void CopyFile(string sourceFileName, string destFileName, bool overwrite)
+        => File.Copy(sourceFileName, destFileName, overwrite);
+
+    /// <inheritdoc/>
     public IEnumerable<string> GetDirectories(string path) => Directory.GetDirectories(path);
+
+    /// <inheritdoc/>
+    public IEnumerable<string> EnumerateDirectories(string path) => Directory.EnumerateDirectories(path);
 
     /// <inheritdoc/>
     public IEnumerable<string> GetFiles(string path, string searchPattern, SearchOption searchOption)
@@ -92,4 +150,7 @@ public sealed class FileSystem : IFileSystem
     /// <inheritdoc/>
     public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
         => Directory.EnumerateFiles(path, searchPattern, searchOption);
+
+    /// <inheritdoc/>
+    public string? GetParentDirectory(string path) => Directory.GetParent(path)?.FullName;
 }

--- a/Services/SchemaService.cs
+++ b/Services/SchemaService.cs
@@ -11,7 +11,43 @@ using PromptLoom.Models;
 
 namespace PromptLoom.Services;
 
-public sealed class SchemaService
+/// <summary>
+/// Abstraction for schema load/save and base folder access.
+/// </summary>
+public interface ISchemaService
+{
+    /// <summary>
+    /// Root directory for schema content.
+    /// </summary>
+    string RootDir { get; }
+
+    /// <summary>
+    /// Categories directory.
+    /// </summary>
+    string CategoriesDir { get; }
+
+    /// <summary>
+    /// Output directory.
+    /// </summary>
+    string OutputDir { get; }
+
+    /// <summary>
+    /// Ensures base folders exist.
+    /// </summary>
+    void EnsureBaseFolders();
+
+    /// <summary>
+    /// Loads categories from disk.
+    /// </summary>
+    List<CategoryModel> Load();
+
+    /// <summary>
+    /// Saves categories to disk.
+    /// </summary>
+    void Save(IEnumerable<CategoryModel> categories);
+}
+
+public sealed class SchemaService : ISchemaService
 {
     public static readonly string[] DefaultCategories =
         ["Subject", "Setting", "Clothing", "Style", "Camera", "Lighting", "Composition", "Quality"];

--- a/Services/SwarmUiService.cs
+++ b/Services/SwarmUiService.cs
@@ -1,0 +1,93 @@
+// FIX: Extract SwarmUI operations behind a service seam for view-model simplicity.
+// CAUSE: MainViewModel directly constructed Swarm clients and handled URL parsing.
+// CHANGE: Introduce IAppSwarmUiService with a default implementation. 2025-12-27
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SwarmUi.Client;
+
+namespace PromptLoom.Services;
+
+/// <summary>
+/// Abstraction for SwarmUI operations used by the app.
+/// </summary>
+public interface IAppSwarmUiService
+{
+    /// <summary>
+    /// Validates and returns the base URI for SwarmUI.
+    /// </summary>
+    Uri GetBaseUri(string swarmUrl);
+
+    /// <summary>
+    /// Checks current status for the SwarmUI server.
+    /// </summary>
+    Task<SwarmStatus> GetStatusAsync(string swarmUrl, string? swarmToken, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists available Stable-Diffusion models.
+    /// </summary>
+    Task<List<string>> ListModelsAsync(string swarmUrl, string? swarmToken, int depth = 6, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists available LoRAs.
+    /// </summary>
+    Task<List<string>> ListLorasAsync(string swarmUrl, string? swarmToken, int depth = 6, CancellationToken ct = default);
+
+    /// <summary>
+    /// Suggests a model and resolution if required by the server.
+    /// </summary>
+    Task<(string? model, int width, int height)> GetSuggestedModelAndResolutionAsync(string swarmUrl, string? swarmToken, CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts a generation via WebSocket, yielding progress frames.
+    /// </summary>
+    IAsyncEnumerable<string> GenerateText2ImageStreamAsync(string swarmUrl, string? swarmToken, GenerateText2ImageRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Interrupts any running generations for the current session.
+    /// </summary>
+    Task<bool> InterruptAllAsync(string swarmUrl, string? swarmToken, bool otherSessions = false, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Default SwarmUI service using the SwarmUI client factory.
+/// </summary>
+public sealed class SwarmUiService : IAppSwarmUiService
+{
+    private readonly ISwarmUiClientFactory _factory;
+
+    public SwarmUiService(ISwarmUiClientFactory factory)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+    }
+
+    public Uri GetBaseUri(string swarmUrl)
+    {
+        if (!Uri.TryCreate(swarmUrl, UriKind.Absolute, out var baseUri))
+            throw new InvalidOperationException($"Invalid SwarmUrl: '{swarmUrl}'. Expected something like http://127.0.0.1:7801");
+        return baseUri;
+    }
+
+    public Task<SwarmStatus> GetStatusAsync(string swarmUrl, string? swarmToken, CancellationToken ct = default)
+        => CreateClient(swarmUrl, swarmToken).GetCurrentStatusAsync(ct);
+
+    public Task<List<string>> ListModelsAsync(string swarmUrl, string? swarmToken, int depth = 6, CancellationToken ct = default)
+        => CreateClient(swarmUrl, swarmToken).ListStableDiffusionModelsAsync(depth, ct);
+
+    public Task<List<string>> ListLorasAsync(string swarmUrl, string? swarmToken, int depth = 6, CancellationToken ct = default)
+        => CreateClient(swarmUrl, swarmToken).ListLorasAsync(depth, ct);
+
+    public Task<(string? model, int width, int height)> GetSuggestedModelAndResolutionAsync(string swarmUrl, string? swarmToken, CancellationToken ct = default)
+        => CreateClient(swarmUrl, swarmToken).GetSuggestedModelAndResolutionAsync(ct);
+
+    public IAsyncEnumerable<string> GenerateText2ImageStreamAsync(string swarmUrl, string? swarmToken, GenerateText2ImageRequest request, CancellationToken ct = default)
+        => CreateClient(swarmUrl, swarmToken).GenerateText2ImageStreamAsync(request, ct);
+
+    public Task<bool> InterruptAllAsync(string swarmUrl, string? swarmToken, bool otherSessions = false, CancellationToken ct = default)
+        => CreateClient(swarmUrl, swarmToken).InterruptAllAsync(otherSessions, ct);
+
+    private IAppSwarmUiClient CreateClient(string swarmUrl, string? swarmToken)
+        => _factory.Create(GetBaseUri(swarmUrl), swarmToken);
+}

--- a/ViewModels/AsyncRelayCommand.cs
+++ b/ViewModels/AsyncRelayCommand.cs
@@ -1,0 +1,70 @@
+// FIX: Provide async command support to surface exceptions and allow awaiting.
+// CAUSE: Async operations in view models used async void, which hides errors.
+// CHANGE: Add AsyncRelayCommand wrapping Func<Task> with error reporting. 2025-12-27
+
+using System.Windows.Input;
+using PromptLoom.Services;
+
+namespace PromptLoom.ViewModels;
+
+public sealed class AsyncRelayCommand : ICommand
+{
+    public string Name { get; }
+    private readonly Func<object?, Task> _execute;
+    private readonly Func<object?, bool>? _canExecute;
+    private readonly IErrorReporter _errors;
+    private bool _isExecuting;
+
+    /// <summary>
+    /// Creates a new async relay command.
+    /// </summary>
+    public AsyncRelayCommand(
+        string name,
+        Func<object?, Task> execute,
+        Func<object?, bool>? canExecute = null,
+        IErrorReporter? errorReporter = null)
+    {
+        Name = name;
+        _execute = execute;
+        _canExecute = canExecute;
+        _errors = errorReporter ?? new ErrorReporterAdapter();
+    }
+
+    public bool CanExecute(object? parameter)
+        => !_isExecuting && (_canExecute?.Invoke(parameter) ?? true);
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter)) return;
+
+        try
+        {
+            _errors.UiEvent("Command", new
+            {
+                name = Name,
+                paramType = parameter?.GetType().Name,
+                param = parameter is null ? null : parameter.ToString()
+            });
+        }
+        catch { }
+
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute(parameter).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _errors.Report(ex, $"Command:{Name}");
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public event EventHandler? CanExecuteChanged;
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}


### PR DESCRIPTION
## Summary
- add IAppSwarmUiService to encapsulate SwarmUI client usage and URL parsing
- introduce AsyncRelayCommand and convert Swarm status/model commands to async tasks
- expand file system schema seams (IFileSystem, ISchemaService) to support future IO unification

## Testing
- dotnet test PromptLoom.Tests/PromptLoom.Tests.csproj -c Release