### PR TITLE
Fix compile glob exclusions for WPF temp builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <!--
 CHANGE LOG
+- 2025-12-31 | Request: Bug fix version bump | Updated BaseVersion to 2.0.1.
 - 2025-12-30 | Fix: Detect WPF temp project names | Disable assembly info when MSBuildProjectName ends with _wpftmp.
 - 2025-12-30 | Fix: Avoid WPF temp assembly dupes | Disable assembly info generation for WPF temporary projects.
 - 2025-12-30 | Request: Bump base version | Updated BaseVersion to 2.0.0.
@@ -15,6 +16,6 @@ CHANGE LOG
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <BaseVersion Condition="'$(BaseVersion)' == ''">2.0.0</BaseVersion>
+    <BaseVersion Condition="'$(BaseVersion)' == ''">2.0.1</BaseVersion>
   </PropertyGroup>
 </Project>

--- a/PromptLoom.csproj
+++ b/PromptLoom.csproj
@@ -1,5 +1,7 @@
 <!--
 CHANGE LOG
+- 2025-12-31 | Request: Exclude referenced project sources | Prevented compiling SwarmUi.Client sources in the app project glob.
+- 2025-12-31 | Request: Prevent nested obj/bin compile | Excluded **\obj\** and **\bin\** from compile and item excludes to avoid duplicate assembly info.
 - 2025-12-29 | Request: Centralize versioning | Removed local version metadata and rely on Directory.Build.props.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
@@ -23,7 +25,7 @@ CHANGE LOG
 
     <!-- Build hardening: never accidentally compile or include stale generated output
          when building from a source zip/folder. -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;obj\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;obj\**;**\bin\**;**\obj\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,6 +42,6 @@ CHANGE LOG
 
   <ItemGroup>
     <!-- Build fix: exclude test sources from the app project to avoid pulling xUnit references into WPF builds. -->
-    <Compile Include="**\*.cs" Exclude="External\**\*.cs;bin\**;obj\**;PromptLoom.Tests\**\*.cs" />
+    <Compile Include="**\*.cs" Exclude="External\**\*.cs;bin\**;obj\**;**\bin\**;**\obj\**;PromptLoom.Tests\**\*.cs;SwarmUi.Client\**\*.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Exclude nested obj/bin and SwarmUi.Client sources from app compile glob to avoid temp WPF duplicate compiles.
- Bump BaseVersion to 2.0.1 per bug-fix policy.

## Testing
- dotnet build .
- dotnet test .

## Pre-PR Submission Check-In
- Build: dotnet build . (pass)
- Tests: dotnet test . (pass)
- Outstanding issues: none
