### PR TITLE
Polish Prompt tab controls

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <!--
 CHANGE LOG
-- 2026-03-02 | Request: Minor version bump | Update BaseVersion to 2.3.0.
+- 2026-03-02 | Request: Patch version bump | Update BaseVersion to 2.1.1.
 - 2025-12-31 | Request: Minor version bump | Update BaseVersion to 2.2.0.
 - 2025-12-31 | Request: MVVM split | Bump BaseVersion to 2.1.0.
 -->
@@ -13,6 +13,6 @@ CHANGE LOG
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <BaseVersion Condition="'$(BaseVersion)' == ''">2.3.0</BaseVersion>
+    <BaseVersion Condition="'$(BaseVersion)' == ''">2.1.1</BaseVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,8 @@
 <!--
 CHANGE LOG
+- 2026-03-02 | Request: Minor version bump | Update BaseVersion to 2.3.0.
 - 2025-12-31 | Request: Minor version bump | Update BaseVersion to 2.2.0.
 - 2025-12-31 | Request: MVVM split | Bump BaseVersion to 2.1.0.
-- 2025-12-31 | Request: Bug fix version bump | Updated BaseVersion to 2.0.1.
-- 2025-12-30 | Fix: Detect WPF temp project names | Disable assembly info when MSBuildProjectName ends with _wpftmp.
-- 2025-12-30 | Fix: Avoid WPF temp assembly dupes | Disable assembly info generation for WPF temporary projects.
-- 2025-12-30 | Request: Bump base version | Updated BaseVersion to 2.0.0.
-- 2025-12-29 | Request: Centralize versioning rules | Added versioning defaults and assembly metadata settings.
-- 2025-12-29 | Request: Build failure (MSB4276 workload SDK resolver) | Disabled workload resolver at solution scope.
 -->
 <Project>
   <PropertyGroup>
@@ -18,6 +13,6 @@ CHANGE LOG
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <BaseVersion Condition="'$(BaseVersion)' == ''">2.2.0</BaseVersion>
+    <BaseVersion Condition="'$(BaseVersion)' == ''">2.3.0</BaseVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <!--
 CHANGE LOG
+- 2025-12-31 | Request: Minor version bump | Update BaseVersion to 2.2.0.
 - 2025-12-31 | Request: MVVM split | Bump BaseVersion to 2.1.0.
 - 2025-12-31 | Request: Bug fix version bump | Updated BaseVersion to 2.0.1.
 - 2025-12-30 | Fix: Detect WPF temp project names | Disable assembly info when MSBuildProjectName ends with _wpftmp.
@@ -17,6 +18,6 @@ CHANGE LOG
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <BaseVersion Condition="'$(BaseVersion)' == ''">2.1.0</BaseVersion>
+    <BaseVersion Condition="'$(BaseVersion)' == ''">2.2.0</BaseVersion>
   </PropertyGroup>
 </Project>

--- a/PromptLoom.Services/UserSettingsStore.cs
+++ b/PromptLoom.Services/UserSettingsStore.cs
@@ -1,3 +1,6 @@
+// CHANGE LOG
+// - 2025-12-31 | Request: Persist SwarmUI toggles | Store send-seed toggle and SwarmUI selections.
+// - 2025-12-25 | Fix: User settings store seam | Add IUserSettingsStore and a default implementation.
 // FIX: Introduce user settings store seam to allow in-memory testing.
 // CAUSE: MainViewModel read/wrote user_settings.json directly.
 // CHANGE: Add IUserSettingsStore and a default implementation. 2025-12-25
@@ -75,6 +78,8 @@ public sealed class UserSettings
 
     public bool SendSwarmCfgScale { get; set; }
     public double SwarmCfgScale { get; set; }
+
+    public bool SendSwarmSeed { get; set; } = true;
 
     public bool SendSwarmLoras { get; set; }
     public string? SwarmSelectedLora1 { get; set; }

--- a/PromptLoom.Services/UserSettingsStore.cs
+++ b/PromptLoom.Services/UserSettingsStore.cs
@@ -1,4 +1,5 @@
 // CHANGE LOG
+// - 2026-03-02 | Request: Batch qty slider | Default batch quantity to 2.
 // - 2025-12-31 | Request: Persist SwarmUI toggles | Store send-seed toggle and SwarmUI selections.
 // - 2025-12-25 | Fix: User settings store seam | Add IUserSettingsStore and a default implementation.
 // FIX: Introduce user settings store seam to allow in-memory testing.
@@ -87,6 +88,6 @@ public sealed class UserSettings
     public string? SwarmSelectedLora2 { get; set; }
     public double SwarmLora2Weight { get; set; } = 1.0;
 
-    public int BatchQty { get; set; } = 1;
+    public int BatchQty { get; set; } = 2;
     public bool BatchRandomizePrompts { get; set; }
 }

--- a/PromptLoom.Tests/SwarmClientSeamTests.cs
+++ b/PromptLoom.Tests/SwarmClientSeamTests.cs
@@ -1,3 +1,5 @@
+// CHANGE LOG
+// - 2025-12-31 | Request: SwarmUI cards | Assert against model/LoRA card names.
 // TEST: Validate SwarmUI seam integration via injected factory and error reporter.
 
 using PromptLoom.Tests.Fakes;
@@ -26,8 +28,8 @@ public class SwarmClientSeamTests
 
         vm.RefreshSwarmModels();
 
-        Assert.Contains("ModelA", vm.SwarmModels);
-        Assert.Contains("ModelB", vm.SwarmModels);
+        Assert.Contains(vm.SwarmModels, m => m.Name == "ModelA");
+        Assert.Contains(vm.SwarmModels, m => m.Name == "ModelB");
     }
 
     /// <summary>
@@ -46,7 +48,7 @@ public class SwarmClientSeamTests
 
         vm.RefreshSwarmLoras();
 
-        Assert.Contains("LoraA", vm.SwarmLoras);
-        Assert.Contains("LoraB", vm.SwarmLoras);
+        Assert.Contains(vm.SwarmLoras, l => l.Name == "LoraA");
+        Assert.Contains(vm.SwarmLoras, l => l.Name == "LoraB");
     }
 }

--- a/PromptLoom.View/Controls/PromptPanel.xaml
+++ b/PromptLoom.View/Controls/PromptPanel.xaml
@@ -1,0 +1,522 @@
+<!--
+CHANGE LOG
+- 2026-03-02 | Request: Batch/seed alignment | Show qty inline and align seed rows.
+- 2026-03-02 | Request: Prompt control layout tweaks | Center headers, inline seeds, and simplify actions.
+- 2026-03-02 | Fix: Prompt panel resources | Scope converters and Swarm card template locally for the shared panel.
+-->
+<UserControl x:Class="PromptLoom.Controls.PromptPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:conv="clr-namespace:PromptLoom.Converters"
+             xmlns:controls="clr-namespace:PromptLoom.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="720"
+             d:DesignWidth="680">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <conv:OneLineTextConverter x:Key="OneLine"/>
+
+        <DataTemplate x:Key="SwarmAssetCardTemplate">
+            <Border Background="#14000000" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
+                    CornerRadius="8" Padding="6" Margin="0,2" ToolTip="{Binding Name}">
+                <StackPanel>
+                    <TextBlock FontWeight="SemiBold" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock FontSize="11" Opacity="0.65" Text="{Binding PathHint}" TextTrimming="CharacterEllipsis"
+                               Visibility="{Binding HasPathHint, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock FontSize="11" Opacity="0.7" Text="{Binding KindLabel}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <Style x:Key="PromptSectionCard" TargetType="Border">
+            <Setter Property="Background" Value="#08FFFFFF"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderSoft}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="10"/>
+            <Setter Property="Padding" Value="8"/>
+            <Setter Property="Margin" Value="0,0,12,8"/>
+        </Style>
+        <Style x:Key="PromptSectionHeader" TargetType="TextBlock">
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Opacity" Value="0.8"/>
+            <Setter Property="Margin" Value="0,0,0,4"/>
+        </Style>
+        <Style x:Key="PromptActionBase" TargetType="Button">
+            <Setter Property="Height" Value="36"/>
+            <Setter Property="Width" Value="170"/>
+            <Setter Property="Padding" Value="12,4"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="#1C1C1C"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="0,0,8,6"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="10"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Effect">
+                                    <Setter.Value>
+                                        <DropShadowEffect BlurRadius="8" ShadowDepth="1" Opacity="0.18"/>
+                                    </Setter.Value>
+                                </Setter>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Bd" Property="RenderTransform">
+                                    <Setter.Value>
+                                        <ScaleTransform ScaleX="0.98" ScaleY="0.98"/>
+                                    </Setter.Value>
+                                </Setter>
+                                <Setter TargetName="Bd" Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Bd" Property="Opacity" Value="0.55"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="PromptActionUtility" TargetType="Button" BasedOn="{StaticResource PromptActionBase}">
+            <Setter Property="Background" Value="#FFF7F8FA"/>
+            <Setter Property="BorderBrush" Value="#33000000"/>
+        </Style>
+        <Style x:Key="PromptActionSpark" TargetType="Button" BasedOn="{StaticResource PromptActionBase}">
+            <Setter Property="Background" Value="#FFFBEFD7"/>
+            <Setter Property="BorderBrush" Value="#66B47A1A"/>
+        </Style>
+        <Style x:Key="PromptActionPrimary" TargetType="Button" BasedOn="{StaticResource PromptActionBase}">
+            <Setter Property="Background">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Color="#FFFFF0F7" Offset="0"/>
+                        <GradientStop Color="#FFFAD1E6" Offset="1"/>
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="BorderBrush" Value="{StaticResource AccentPink}"/>
+        </Style>
+        <Style x:Key="PromptActionSecondary" TargetType="Button" BasedOn="{StaticResource PromptActionBase}">
+            <Setter Property="Background">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Color="#FFE6FBFF" Offset="0"/>
+                        <GradientStop Color="#FFCDEFF7" Offset="1"/>
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="BorderBrush" Value="{StaticResource AccentCyan}"/>
+        </Style>
+    </UserControl.Resources>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+            <TextBlock FontSize="26" FontWeight="SemiBold" Text="Prompt" Foreground="{StaticResource AccentPink}"/>
+            <TextBlock Opacity="0.75" Text="Updates live. If empty, check System Messages."/>
+        </StackPanel>
+
+        <Border Background="{StaticResource PanelBg}" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" CornerRadius="14" Padding="12" Margin="0,0,0,10">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <TabControl Grid.Row="1" Margin="0" Background="Transparent" VerticalAlignment="Stretch">
+                    <TabItem Header="Prompt">
+                        <Border Padding="8" Background="Transparent">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <!-- Top controls -->
+                                <StackPanel Grid.Row="0" Margin="0,0,0,8">
+                                    <WrapPanel HorizontalAlignment="Center" Margin="0,0,0,6">
+                                            <Button Command="{Binding CopyCommand}" ToolTip="Copy prompt to clipboard">
+                                                <Button.Style>
+                                                    <Style TargetType="Button" BasedOn="{StaticResource PromptActionUtility}">
+                                                        <Setter Property="Content" Value="Copy Prompt"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding CopyButtonText}" Value="Copied!">
+                                                                <Setter Property="Content" Value="Copied!"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Button.Style>
+                                            </Button>
+                                            <Button Content="&#x1F3B2; Random"
+                                                    Style="{StaticResource PromptActionSpark}"
+                                                    Command="{Binding RandomizeCommand}"
+                                                    ToolTip="Randomize the current prompt"/>
+                                            <Button Content="{Binding SwarmButtonText}"
+                                                    Style="{StaticResource PromptActionPrimary}"
+                                                    Command="{Binding SendToSwarmUiCommand}"
+                                                    ToolTip="Send the prompt to SwarmUI"/>
+                                    </WrapPanel>
+
+                                    <WrapPanel HorizontalAlignment="Center">
+                                        <Border Style="{StaticResource PromptSectionCard}" MinWidth="240">
+                                            <StackPanel>
+                                                <TextBlock Style="{StaticResource PromptSectionHeader}" Text="Batch" HorizontalAlignment="Center"/>
+                                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                    <TextBlock Height="28"
+                                                               Margin="0,0,8,0"
+                                                               Opacity="0.75"
+                                                               VerticalAlignment="Center"
+                                                               Text="{Binding BatchQty, StringFormat=Qty:{0}}"/>
+                                                    <Slider Width="120"
+                                                            Height="28"
+                                                            Minimum="2"
+                                                            Maximum="50"
+                                                            TickFrequency="1"
+                                                            IsSnapToTickEnabled="True"
+                                                            Value="{Binding BatchQty, UpdateSourceTrigger=PropertyChanged}"/>
+                                                    <CheckBox Content="&#x1F3B2;"
+                                                              Height="28"
+                                                              Margin="12,0,0,0"
+                                                              VerticalAlignment="Center"
+                                                              ToolTip="Randomize prompts in the batch"
+                                                              IsChecked="{Binding BatchRandomizePrompts}"/>
+                                                </StackPanel>
+                                                <Button Content="Batch Generate"
+                                                        Height="28"
+                                                        Margin="0,6,0,0"
+                                                        Command="{Binding SendBatchToSwarmUiCommand}"/>
+                                            </StackPanel>
+                                        </Border>
+
+                                        <Border Style="{StaticResource PromptSectionCard}" MinWidth="240">
+                                            <StackPanel>
+                                                <TextBlock Style="{StaticResource PromptSectionHeader}" Text="Seeds" HorizontalAlignment="Center"/>
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="18"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <Border Grid.Row="0" Grid.Column="0" Width="18" Height="28"/>
+                                                    <TextBlock Grid.Row="0" Grid.Column="1"
+                                                               Opacity="0.75"
+                                                               Text="Prompt:"
+                                                               Height="28"
+                                                               Margin="0,0,6,0"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBox Grid.Row="0" Grid.Column="2"
+                                                             Width="160"
+                                                             Background="{StaticResource InputCyan}"
+                                                             Height="28"
+                                                             VerticalContentAlignment="Center"
+                                                             Text="{Binding PromptSeedText, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                                    <CheckBox Grid.Row="1" Grid.Column="0"
+                                                              Width="18"
+                                                              Margin="0,6,0,0"
+                                                              Height="28"
+                                                              VerticalAlignment="Center"
+                                                              ToolTip="Send image seed to SwarmUI"
+                                                              IsChecked="{Binding SendSwarmSeed}"/>
+                                                    <TextBlock Grid.Row="1" Grid.Column="1"
+                                                               Opacity="0.75"
+                                                               Text="Image:"
+                                                               Height="28"
+                                                               Margin="0,6,6,0"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBox Grid.Row="1" Grid.Column="2"
+                                                             Width="160"
+                                                             Height="28"
+                                                             Margin="0,6,0,0"
+                                                             Background="{StaticResource InputCyan}"
+                                                             VerticalContentAlignment="Center"
+                                                             Text="{Binding ImageSeedText, UpdateSourceTrigger=PropertyChanged}"/>
+                                                </Grid>
+                                            </StackPanel>
+                                        </Border>
+                                    </WrapPanel>
+                                </StackPanel>
+
+                                <controls:AutoSizeTextBox Grid.Row="1"
+                                                          MaxAutoHeight="260"
+                                                          Background="{StaticResource PromptPink}"
+                                                          FontSize="14"
+                                                          Text="{Binding PromptText, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                <!-- Recent batches fill the rest -->
+                                <Border Grid.Row="2" CornerRadius="12" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
+                                        Background="{StaticResource PanelBg}" Padding="8" Margin="0,10,0,10">
+                                    <DockPanel LastChildFill="True">
+                                        <TextBlock DockPanel.Dock="Top" FontWeight="SemiBold" Text="Latest Images" Margin="0,0,0,6"/>
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                            <ItemsControl ItemsSource="{Binding RecentBatches}">
+                                                <ItemsControl.Resources>
+                                                    <!-- Thumbnail card used by both batch styles -->
+                                                    <DataTemplate x:Key="ThumbTemplate">
+                                                        <Border Width="160" Height="160" Margin="0,0,8,8" CornerRadius="10" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Background="#0A000000" Padding="6">
+                                                            <Grid>
+                                                                <Button Background="Transparent" BorderThickness="0" Padding="0"
+                                                                        Command="{Binding DataContext.ShowImageOverlayCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding}">
+                                                                    <Image Source="{Binding Thumbnail}" Stretch="UniformToFill" />
+                                                                </Button>
+                                                                <Border Background="#99000000" CornerRadius="8" Padding="6"
+                                                                        IsHitTestVisible="False"
+                                                                        Visibility="{Binding IsGenerating, Converter={StaticResource BoolToVis}}">
+                                                                    <StackPanel VerticalAlignment="Bottom">
+                                                                        <TextBlock Foreground="#FFF" FontSize="11" FontWeight="SemiBold"
+                                                                                   Text="{Binding Status}" TextTrimming="CharacterEllipsis"/>
+                                                                        <TextBlock Foreground="#E6FFFFFF" FontSize="11" Margin="0,2,0,0"
+                                                                                   Text="{Binding StepProgressText}"
+                                                                                   Visibility="{Binding HasStepProgress, Converter={StaticResource BoolToVis}}"/>
+                                                                        <ProgressBar Height="6" Margin="0,4,0,0" Minimum="0" Maximum="1"
+                                                                                     Value="{Binding Progress}" IsIndeterminate="{Binding IsIndeterminate}"/>
+                                                                    </StackPanel>
+                                                                </Border>
+                                                            </Grid>
+                                                        </Border>
+                                                    </DataTemplate>
+
+                                                    <!-- 4+ images: render as a compact batch card that can sit side-by-side -->
+                                                    <DataTemplate x:Key="BatchCardTemplate">
+                                                        <Border Margin="0,0,12,12" CornerRadius="12" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Background="#06000000" Padding="8" MinWidth="320">
+                                                            <DockPanel>
+                                                                <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <TextBlock FontWeight="SemiBold" Text="{Binding Title, Converter={StaticResource OneLine}}"/>
+                                                                        <TextBlock Opacity="0.655" Margin="10,0,0,0" Text="{Binding Items.Count, StringFormat=({0})}"/>
+                                                                    </StackPanel>
+                                                                    <TextBlock Opacity="0.78" FontSize="12" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                                                                               Text="{Binding PromptSnippet, Converter={StaticResource OneLine}}"/>
+                                                                    <TextBlock Opacity="0.65" FontSize="12" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                                                                               Text="{Binding SettingsSummary, Converter={StaticResource OneLine}}"/>
+                                                                </StackPanel>
+
+                                                                <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                                                                    <ItemsControl ItemsSource="{Binding Items}" ItemTemplate="{StaticResource ThumbTemplate}">
+                                                                        <ItemsControl.ItemsPanel>
+                                                                            <ItemsPanelTemplate>
+                                                                                <StackPanel Orientation="Horizontal"/>
+                                                                            </ItemsPanelTemplate>
+                                                                        </ItemsControl.ItemsPanel>
+                                                                    </ItemsControl>
+                                                                </ScrollViewer>
+                                                            </DockPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+
+                                                    <!-- 1-3 images: render as a vertical label separator with thumbnails to its right -->
+                                                    <DataTemplate x:Key="BatchSmallTemplate">
+                                                        <Border Margin="0,0,12,12" Background="#03000000" BorderBrush="#22000000" BorderThickness="1" CornerRadius="10" Padding="6">
+                                                            <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="32"/>
+                                                                    <ColumnDefinition Width="Auto"/>
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <!-- Vertical label -->
+                                                                <Border Grid.Column="0" Background="#0A000000" CornerRadius="8" Padding="2" Margin="0,0,6,8" VerticalAlignment="Stretch" MinHeight="160">
+                                                                    <TextBlock VerticalAlignment="Center" FontWeight="SemiBold" FontSize="11" Opacity="0.85" TextTrimming="CharacterEllipsis">
+                                                                        <TextBlock.LayoutTransform>
+                                                                            <RotateTransform Angle="-90"/>
+                                                                        </TextBlock.LayoutTransform>
+                                                                        <TextBlock.Text>
+                                                                            <!-- NOTE: XAML treats "{...}" as a markup extension unless escaped. Prefix with "{}" for a literal format string. -->
+                                                                            <MultiBinding StringFormat="{}{0} &#x00B7; {1}">
+                                                                                <Binding Path="Title" Converter="{StaticResource OneLine}"/>
+                                                                                <Binding Path="PromptSnippet" Converter="{StaticResource OneLine}"/>
+                                                                            </MultiBinding>
+                                                                        </TextBlock.Text>
+                                                                    </TextBlock>
+                                                                </Border>
+
+                                                                <!-- Thumbnails -->
+                                                                <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                                                                    <ItemsControl x:Name="SmallThumbs" ItemsSource="{Binding Items}" ItemTemplate="{StaticResource ThumbTemplate}">
+                                                                        <ItemsControl.ItemsPanel>
+                                                                            <ItemsPanelTemplate>
+                                                                                <StackPanel Orientation="Horizontal"/>
+                                                                            </ItemsPanelTemplate>
+                                                                        </ItemsControl.ItemsPanel>
+                                                                    </ItemsControl>
+                                                                </ScrollViewer>
+                                                            </Grid>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.Resources>
+
+                                                <!-- IMPORTANT: top-level is a wrap panel so batches can flow left-to-right and only wrap when needed -->
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <WrapPanel Orientation="Horizontal"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl Content="{Binding}">
+                                                            <ContentControl.Style>
+                                                                <Style TargetType="ContentControl">
+                                                                    <Setter Property="ContentTemplate" Value="{StaticResource BatchSmallTemplate}"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsCard}" Value="True">
+                                                                            <Setter Property="ContentTemplate" Value="{StaticResource BatchCardTemplate}"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </ContentControl.Style>
+                                                        </ContentControl>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </DockPanel>
+                                </Border>
+
+                                <!-- Status pinned to bottom (3 lines) -->
+                                <Border Grid.Row="3" CornerRadius="8" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
+                                        Background="{StaticResource PanelBg}" Padding="8">
+                                    <DockPanel>
+                                        <TextBlock DockPanel.Dock="Top" FontWeight="SemiBold" Text="Status" Margin="0,0,0,4"/>
+                                        <TextBox Text="{Binding SystemMessages}" TextWrapping="Wrap" IsReadOnly="True"
+                                                 BorderThickness="0" Background="Transparent" Height="54" VerticalScrollBarVisibility="Auto"/>
+                                    </DockPanel>
+                                </Border>
+                            </Grid>
+                        </Border>
+                    </TabItem>
+                    <TabItem Header="SwarmUI">
+                        <Border Padding="10" Background="Transparent">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <StackPanel>
+                                    <TextBlock FontSize="24" FontWeight="SemiBold" Foreground="{StaticResource AccentPink}" Text="SwarmUI"/>
+                                    <TextBlock Margin="0,4,0,12" Opacity="0.75" Text="Connection + tools for realtime generation and model selection."/>
+
+                                    <TextBlock FontWeight="SemiBold" Text="Server URL"/>
+                                    <TextBox Margin="0,6,0,12" Background="{StaticResource InputCyan}"
+                                             Text="{Binding SwarmUrl, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                    <TextBlock FontWeight="SemiBold" Text="Auth Token (optional)"/>
+                                    <TextBox Margin="0,6,0,12" Background="{StaticResource InputCyan}"
+                                             Text="{Binding SwarmToken, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
+                                        <CheckBox Content="Send Model Override" IsChecked="{Binding SendSwarmModelOverride}" Margin="0,0,12,0"/>
+                                        <TextBlock FontWeight="SemiBold" Text="Model" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,12">
+                                        <ComboBox MinWidth="360" Background="{StaticResource InputCyan}"
+                                                  IsEnabled="{Binding CanEditSwarmModelOverride}"
+                                                  ItemsSource="{Binding SwarmModels}"
+                                                  ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
+                                                  SelectedValuePath="Name"
+                                                  SelectedValue="{Binding SwarmSelectedModel, UpdateSourceTrigger=PropertyChanged}"/>
+                                        <Button Width="150" Margin="8,0,0,0" Content="Refresh Models" Command="{Binding RefreshSwarmModelsCommand}"/>
+                                    </StackPanel>
+
+                                    <Border CornerRadius="10" Background="{StaticResource PanelBg}" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Padding="10" Margin="0,0,0,12">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="SemiBold" Text="Generation Overrides" Margin="0,0,0,8"/>
+
+                                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                                <CheckBox Content="Send Steps" IsChecked="{Binding SendSwarmSteps}" Margin="0,0,12,0"/>
+                                                <TextBlock Opacity="0.75" Text="Steps:" VerticalAlignment="Center"/>
+                                                <TextBox Width="80" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
+                                                         IsEnabled="{Binding CanEditSwarmSteps}"
+                                                         Text="{Binding SwarmSteps, UpdateSourceTrigger=PropertyChanged}"/>
+                                            </StackPanel>
+
+                                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                                <CheckBox Content="Send CFG Scale" IsChecked="{Binding SendSwarmCfgScale}" Margin="0,0,12,0"/>
+                                                <TextBlock Opacity="0.75" Text="CFG:" VerticalAlignment="Center"/>
+                                                <TextBox Width="80" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
+                                                         IsEnabled="{Binding CanEditSwarmCfgScale}"
+                                                         Text="{Binding SwarmCfgScale, UpdateSourceTrigger=PropertyChanged}"/>
+                                            </StackPanel>
+
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
+                                                <CheckBox Content="Send LoRAs" IsChecked="{Binding SendSwarmLoras}" Margin="0,0,12,0"/>
+                                                <TextBlock FontWeight="SemiBold" Text="LoRAs" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                            <StackPanel Orientation="Horizontal" Margin="0,6,0,8">
+                                                <ComboBox MinWidth="300" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
+                                                          ItemsSource="{Binding SwarmLoras}"
+                                                          ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
+                                                          SelectedValuePath="Name"
+                                                          SelectedValue="{Binding SwarmSelectedLora1, UpdateSourceTrigger=PropertyChanged}"/>
+                                                <TextBlock Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" Text="Weight:"/>
+                                                <TextBox Width="70" Margin="8,0,0,0" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
+                                                         Text="{Binding SwarmLora1Weight, UpdateSourceTrigger=PropertyChanged}"/>
+                                            </StackPanel>
+                                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                                <ComboBox MinWidth="300" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
+                                                          ItemsSource="{Binding SwarmLoras}"
+                                                          ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
+                                                          SelectedValuePath="Name"
+                                                          SelectedValue="{Binding SwarmSelectedLora2, UpdateSourceTrigger=PropertyChanged}"/>
+                                                <TextBlock Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" Text="Weight:"/>
+                                                <TextBox Width="70" Margin="8,0,0,0" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
+                                                         Text="{Binding SwarmLora2Weight, UpdateSourceTrigger=PropertyChanged}"/>
+                                            </StackPanel>
+
+                                            <Button Width="150" Content="Refresh LoRAs" Command="{Binding RefreshSwarmLorasCommand}"/>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                        <Button Width="150" Margin="0,0,8,0" Content="Test Connection" Command="{Binding TestSwarmConnectionCommand}"/>
+                                        <Button Width="150" Content="Open SwarmUI" Command="{Binding OpenSwarmUiCommand}"/>
+                                    </StackPanel>
+
+                                    <Border CornerRadius="10" Background="{StaticResource PanelBg}" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Padding="10">
+                                        <TextBlock Text="{Binding SwarmUiStatusText}" TextWrapping="Wrap"/>
+                                    </Border>
+                                </StackPanel>
+                            </ScrollViewer>
+                        </Border>
+                    </TabItem>
+                    <TabItem Header="System">
+                        <Border Padding="8" Background="Transparent">
+                            <ListBox ItemsSource="{Binding ErrorEntries}" />
+                        </Border>
+                    </TabItem>
+                    <TabItem Header="File Editor">
+                        <Border Padding="8" Background="Transparent">
+                            <DockPanel>
+                                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,8">
+                                    <Button Content="Save" Width="90" Margin="0,0,8,0" Command="{Binding SaveEntryFileCommand}"/>
+                                    <Button Content="Open" Width="90" Margin="0,0,8,0" Command="{Binding OpenEntryFileCommand}"/>
+                                    <TextBlock Opacity="0.75" VerticalAlignment="Center" Text="{Binding EntryEditorPath}" TextTrimming="CharacterEllipsis"/>
+                                </StackPanel>
+                                <TextBox Text="{Binding EntryEditorText, UpdateSourceTrigger=PropertyChanged}"
+                                         TextWrapping="Wrap" AcceptsReturn="True"
+                                         VerticalScrollBarVisibility="Auto"
+                                         Background="{StaticResource InputCyan}"
+                                         FontSize="13"/>
+                            </DockPanel>
+                        </Border>
+                    </TabItem>
+                </TabControl>
+            </Grid>
+        </Border>
+    </DockPanel>
+</UserControl>

--- a/PromptLoom.View/Controls/PromptPanel.xaml.cs
+++ b/PromptLoom.View/Controls/PromptPanel.xaml.cs
@@ -1,0 +1,19 @@
+// CHANGE LOG
+// - 2026-03-02 | Request: Deduplicate prompt panel | Add code-behind for shared prompt panel control.
+using System.Windows.Controls;
+
+namespace PromptLoom.Controls;
+
+/// <summary>
+/// Shared prompt panel UI for both wide and stacked layouts.
+/// </summary>
+public partial class PromptPanel : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PromptPanel"/> class.
+    /// </summary>
+    public PromptPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/PromptLoom.View/MainWindow.xaml
+++ b/PromptLoom.View/MainWindow.xaml
@@ -1,7 +1,7 @@
 <!-- CHANGE LOG -->
+<!-- - 2026-03-02 | Request: Deduplicate prompt panel | Reuse shared prompt UI control for both layouts. -->
 <!-- - 2025-12-31 | Request: Single-image label sizing | Align small-batch labels with thumbnail height. -->
 <!-- - 2025-12-31 | Request: SwarmUI cards + toggles | Add model/LoRA cards and send toggles. -->
-<!-- - 2025-12-31 | Request: SwarmUI step progress | Overlay thumbnail cards with generation steps. -->
 <!-- Bugfix: Fix duplicate IconBtn resource key by renaming base style to IconBtnBase so style lookups are unambiguous. -->
 <!-- Bugfix: Allow the shared IconBtn style to apply to ToggleButton instances to prevent XamlParseException popups triggered by a Button-only style target. -->
 <Window x:Class="PromptLoom.MainWindow"
@@ -220,11 +220,11 @@
                                                         CommandParameter="{Binding}"><Path Style="{StaticResource IconPath}" Data="{StaticResource IcoSelectNone}"/></Button>
 	                                                <ToggleButton Style="{StaticResource IconToggleBtn}"
 	                                                             ToolTip="Lock category (exclude from randomization)"
-	                                                             IsChecked="{Binding IsLocked}" Content="🔒"/>
+	                                                             IsChecked="{Binding IsLocked}" Content="≡ƒöÆ"/>
 	                                                <Button Style="{StaticResource IconBtn}"
 	                                                        ToolTip="Randomize this category"
 	                                                        Command="{Binding DataContext.RandomizeCategoryOnceCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-	                                                        CommandParameter="{Binding}" Content="🎲"/>
+	                                                        CommandParameter="{Binding}" Content="≡ƒÄ▓"/>
 </UniformGrid>
                                             
                                         </DockPanel>
@@ -266,11 +266,11 @@
                                                                             CommandParameter="{Binding}"><Path Style="{StaticResource IconPath}" Data="{StaticResource IcoChevronDown}"/></Button>
 	                                                                    <ToggleButton Style="{StaticResource IconToggleBtn}"
 	                                                                                 ToolTip="Lock subcategory (exclude from randomization)"
-	                                                                                 IsChecked="{Binding IsLocked}" Content="🔒"/>
+	                                                                                 IsChecked="{Binding IsLocked}" Content="≡ƒöÆ"/>
 	                                                                    <Button Style="{StaticResource IconBtn}"
 	                                                                            ToolTip="Randomize this subcategory"
 	                                                                            Command="{Binding DataContext.RandomizeSubCategoryOnceCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-	                                                                            CommandParameter="{Binding}" Content="🎲"/>
+	                                                                            CommandParameter="{Binding}" Content="≡ƒÄ▓"/>
 </UniformGrid>
                                                                 <Button
                                                                         CommandParameter="{Binding}" Command="{Binding DataContext.SelectSubCategoryCommand, RelativeSource={RelativeSource AncestorType=Window}}" Content="{Binding Name}" Background="Transparent" BorderThickness="0" Padding="6,2" HorizontalAlignment="Left"/></DockPanel>
@@ -540,367 +540,7 @@
             </DockPanel>
 
             <!-- Prompt -->
-            <DockPanel Grid.Column="2">
-                <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
-                    <TextBlock FontSize="26" FontWeight="SemiBold" Text="Prompt" Foreground="{StaticResource AccentPink}"/>
-                    <TextBlock Opacity="0.75" Text="Updates live. If empty, check System Messages."/>
-                </StackPanel>
-
-                <Border Background="{StaticResource PanelBg}" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" CornerRadius="14" Padding="12" Margin="0,0,0,10">
-                    <Grid>
-                        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-<TabControl Grid.Row="1" Margin="0" Background="Transparent" VerticalAlignment="Stretch">
-            <TabItem Header="Prompt">
-    <Border Padding="8" Background="Transparent">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-
-<!-- Top controls -->
-
-
-<Grid Grid.Row="0" Margin="0,0,0,10">
-
-
-    <Grid.ColumnDefinitions>
-
-
-        <ColumnDefinition Width="*"/>
-
-
-        <ColumnDefinition Width="Auto"/>
-
-
-    </Grid.ColumnDefinitions>
-
-
-
-    <WrapPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,12,0">
-
-
-        <Button Content="{Binding CopyButtonText}" Width="110" Margin="0,0,8,0" Command="{Binding CopyCommand}"/>
-
-
-        <Button Content="🎲 Randomize" Width="130" Margin="0,0,12,0" Command="{Binding RandomizeCommand}"/>
-
-
-        <Button Content="{Binding SwarmButtonText}" Width="160" Margin="0,0,12,0" Command="{Binding SendToSwarmUiCommand}"/>
-
-
-        <Button Content="Batch Generate" Width="140" Margin="0,0,0,0" Command="{Binding SendBatchToSwarmUiCommand}"/>
-
-
-    </WrapPanel>
-
-
-
-    <WrapPanel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">
-
-
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Qty:"/>
-
-
-        <TextBox Width="52" Margin="8,0,12,0" Background="{StaticResource InputCyan}"
-
-
-                 HorizontalAlignment="Right"
-
-
-                 Text="{Binding BatchQty, UpdateSourceTrigger=PropertyChanged}"/>
-
-
-        <CheckBox Content="Randomize Prompts" VerticalAlignment="Center" IsChecked="{Binding BatchRandomizePrompts}" Margin="0,0,12,0"/>
-
-
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Prompt Seed:"/>
-        <TextBox Width="120" MinWidth="90" Margin="8,0,12,0" Background="{StaticResource InputCyan}"
-                 Text="{Binding PromptSeedText, UpdateSourceTrigger=PropertyChanged}" />
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Image Seed:"/>
-        <TextBox Width="120" MinWidth="90" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
-                 Text="{Binding ImageSeedText, UpdateSourceTrigger=PropertyChanged}" />
-
-
-    </WrapPanel>
-
-
-</Grid><!-- Prompt (auto-sized) -->
-            <controls:AutoSizeTextBox Grid.Row="1"
-                                     MaxAutoHeight="260"
-                                     Background="{StaticResource PromptPink}"
-                                     FontSize="14"
-                                     Text="{Binding PromptText, UpdateSourceTrigger=PropertyChanged}"/>
-
-            <!-- Recent batches fill the rest -->
-            <Border Grid.Row="2" CornerRadius="12" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
-                    Background="{StaticResource PanelBg}" Padding="8" Margin="0,10,0,10">
-                <DockPanel LastChildFill="True">
-                    <TextBlock DockPanel.Dock="Top" FontWeight="SemiBold" Text="Latest Images" Margin="0,0,0,6"/>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                        <ItemsControl ItemsSource="{Binding RecentBatches}">
-                            <ItemsControl.Resources>
-                                <!-- Thumbnail card used by both batch styles -->
-                                <DataTemplate x:Key="ThumbTemplate">
-                                    <Border Width="160" Height="160" Margin="0,0,8,8" CornerRadius="10" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Background="#0A000000" Padding="6">
-                                        <Grid>
-                                            <Button Background="Transparent" BorderThickness="0" Padding="0"
-                                                    Command="{Binding DataContext.ShowImageOverlayCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                    CommandParameter="{Binding}">
-                                                <Image Source="{Binding Thumbnail}" Stretch="UniformToFill" />
-                                            </Button>
-                                            <Border Background="#99000000" CornerRadius="8" Padding="6"
-                                                    IsHitTestVisible="False"
-                                                    Visibility="{Binding IsGenerating, Converter={StaticResource BoolToVis}}">
-                                                <StackPanel VerticalAlignment="Bottom">
-                                                    <TextBlock Foreground="#FFF" FontSize="11" FontWeight="SemiBold"
-                                                               Text="{Binding Status}" TextTrimming="CharacterEllipsis"/>
-                                                    <TextBlock Foreground="#E6FFFFFF" FontSize="11" Margin="0,2,0,0"
-                                                               Text="{Binding StepProgressText}"
-                                                               Visibility="{Binding HasStepProgress, Converter={StaticResource BoolToVis}}"/>
-                                                    <ProgressBar Height="6" Margin="0,4,0,0" Minimum="0" Maximum="1"
-                                                                 Value="{Binding Progress}" IsIndeterminate="{Binding IsIndeterminate}"/>
-                                                </StackPanel>
-                                            </Border>
-                                        </Grid>
-                                    </Border>
-                                </DataTemplate>
-
-                                <!-- 4+ images: render as a compact batch card that can sit side-by-side -->
-                                <DataTemplate x:Key="BatchCardTemplate">
-                                    <Border Margin="0,0,12,12" CornerRadius="12" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Background="#06000000" Padding="8" MinWidth="320">
-                                        <DockPanel>
-                                            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
-                                                <StackPanel Orientation="Horizontal">
-                                                    <TextBlock FontWeight="SemiBold" Text="{Binding Title, Converter={StaticResource OneLine}}"/>
-                                                    <TextBlock Opacity="0.65" Margin="10,0,0,0" Text="{Binding Items.Count, StringFormat=({0})}"/>
-                                                </StackPanel>
-                                                <TextBlock Opacity="0.78" FontSize="12" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
-                                                           Text="{Binding PromptSnippet, Converter={StaticResource OneLine}}"/>
-                                                <TextBlock Opacity="0.65" FontSize="12" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
-                                                           Text="{Binding SettingsSummary, Converter={StaticResource OneLine}}"/>
-                                            </StackPanel>
-
-	                                            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
-	                                                <ItemsControl ItemsSource="{Binding Items}" ItemTemplate="{StaticResource ThumbTemplate}">
-	                                                    <ItemsControl.ItemsPanel>
-	                                                        <ItemsPanelTemplate>
-	                                                            <StackPanel Orientation="Horizontal"/>
-	                                                        </ItemsPanelTemplate>
-	                                                    </ItemsControl.ItemsPanel>
-	                                                </ItemsControl>
-	                                            </ScrollViewer>
-                                        </DockPanel>
-                                    </Border>
-                                </DataTemplate>
-
-                                <!-- 1-3 images: render as a vertical label separator with thumbnails to its right -->
-                                <DataTemplate x:Key="BatchSmallTemplate">
-                                    <Border Margin="0,0,12,12" Background="#03000000" BorderBrush="#22000000" BorderThickness="1" CornerRadius="10" Padding="6">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="32"/>
-                                                <ColumnDefinition Width="Auto"/>
-                                            </Grid.ColumnDefinitions>
-
-                                            <!-- Vertical label -->
-                                            <Border Grid.Column="0" Background="#0A000000" CornerRadius="8" Padding="2" Margin="0,0,6,8" VerticalAlignment="Stretch" MinHeight="160">
-                                                <TextBlock VerticalAlignment="Center" FontWeight="SemiBold" FontSize="11" Opacity="0.85" TextTrimming="CharacterEllipsis">
-                                                    <TextBlock.LayoutTransform>
-                                                        <RotateTransform Angle="-90"/>
-                                                    </TextBlock.LayoutTransform>
-                                                    <TextBlock.Text>
-															<!-- NOTE: XAML treats "{...}" as a markup extension unless escaped. Prefix with "{}" for a literal format string. -->
-															<MultiBinding StringFormat="{}{0} · {1}">
-                                                            <Binding Path="Title" Converter="{StaticResource OneLine}"/>
-                                                            <Binding Path="PromptSnippet" Converter="{StaticResource OneLine}"/>
-                                                        </MultiBinding>
-                                                    </TextBlock.Text>
-                                                </TextBlock>
-                                            </Border>
-
-                                            <!-- Thumbnails -->
-	                                            <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
-	                                                <ItemsControl x:Name="SmallThumbs" ItemsSource="{Binding Items}" ItemTemplate="{StaticResource ThumbTemplate}">
-	                                                    <ItemsControl.ItemsPanel>
-	                                                        <ItemsPanelTemplate>
-	                                                            <StackPanel Orientation="Horizontal"/>
-	                                                        </ItemsPanelTemplate>
-	                                                    </ItemsControl.ItemsPanel>
-	                                                </ItemsControl>
-	                                            </ScrollViewer>
-                                        </Grid>
-                                    </Border>
-                                </DataTemplate>
-                            </ItemsControl.Resources>
-
-                            <!-- IMPORTANT: top-level is a wrap panel so batches can flow left-to-right and only wrap when needed -->
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <WrapPanel Orientation="Horizontal"/>
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <ContentControl Content="{Binding}">
-                                        <ContentControl.Style>
-                                            <Style TargetType="ContentControl">
-                                                <Setter Property="ContentTemplate" Value="{StaticResource BatchSmallTemplate}"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsCard}" Value="True">
-                                                        <Setter Property="ContentTemplate" Value="{StaticResource BatchCardTemplate}"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </ContentControl.Style>
-                                    </ContentControl>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </ScrollViewer>
-                </DockPanel>
-            </Border>
-
-            <!-- Status pinned to bottom (3 lines) -->
-            <Border Grid.Row="3" CornerRadius="8" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
-                    Background="{StaticResource PanelBg}" Padding="8">
-                <DockPanel>
-                    <TextBlock DockPanel.Dock="Top" FontWeight="SemiBold" Text="Status" Margin="0,0,0,4"/>
-                    <TextBox Text="{Binding SystemMessages}" TextWrapping="Wrap" IsReadOnly="True"
-                             BorderThickness="0" Background="Transparent" Height="54" VerticalScrollBarVisibility="Auto"/>
-                </DockPanel>
-            </Border>
-        </Grid>
-    </Border>
-</TabItem>
-    <TabItem Header="SwarmUI">
-        <Border Padding="10" Background="Transparent">
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel>
-                    <TextBlock FontSize="24" FontWeight="SemiBold" Foreground="{StaticResource AccentPink}" Text="SwarmUI"/>
-                    <TextBlock Margin="0,4,0,12" Opacity="0.75" Text="Connection + tools for realtime generation and model selection."/>
-
-                    <TextBlock FontWeight="SemiBold" Text="Server URL"/>
-                    <TextBox Margin="0,6,0,12" Background="{StaticResource InputCyan}"
-                             Text="{Binding SwarmUrl, UpdateSourceTrigger=PropertyChanged}"/>
-
-                    <TextBlock FontWeight="SemiBold" Text="Auth Token (optional)"/>
-                    <TextBox Margin="0,6,0,12" Background="{StaticResource InputCyan}"
-                             Text="{Binding SwarmToken, UpdateSourceTrigger=PropertyChanged}"/>
-
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
-                        <CheckBox Content="Send Model Override" IsChecked="{Binding SendSwarmModelOverride}" Margin="0,0,12,0"/>
-                        <TextBlock FontWeight="SemiBold" Text="Model" VerticalAlignment="Center"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="0,6,0,12">
-                        <ComboBox MinWidth="360" Background="{StaticResource InputCyan}"
-                                  IsEnabled="{Binding CanEditSwarmModelOverride}"
-                                  ItemsSource="{Binding SwarmModels}"
-                                  ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
-                                  SelectedValuePath="Name"
-                                  SelectedValue="{Binding SwarmSelectedModel, UpdateSourceTrigger=PropertyChanged}"/>
-                        <Button Width="150" Margin="8,0,0,0" Content="Refresh Models" Command="{Binding RefreshSwarmModelsCommand}"/>
-                    </StackPanel>
-
-                    <Border CornerRadius="10" Background="{StaticResource PanelBg}" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Padding="10" Margin="0,0,0,12">
-                        <StackPanel>
-                            <TextBlock FontWeight="SemiBold" Text="Generation Overrides" Margin="0,0,0,8"/>
-
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <CheckBox Content="Send Steps" IsChecked="{Binding SendSwarmSteps}" Margin="0,0,12,0"/>
-                                <TextBlock Opacity="0.75" Text="Steps:" VerticalAlignment="Center"/>
-                                <TextBox Width="80" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
-                                         IsEnabled="{Binding CanEditSwarmSteps}"
-                                         Text="{Binding SwarmSteps, UpdateSourceTrigger=PropertyChanged}"/>
-                            </StackPanel>
-
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                                <CheckBox Content="Send CFG Scale" IsChecked="{Binding SendSwarmCfgScale}" Margin="0,0,12,0"/>
-                                <TextBlock Opacity="0.75" Text="CFG:" VerticalAlignment="Center"/>
-                                <TextBox Width="80" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
-                                         IsEnabled="{Binding CanEditSwarmCfgScale}"
-                                         Text="{Binding SwarmCfgScale, UpdateSourceTrigger=PropertyChanged}"/>
-                            </StackPanel>
-
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                                <CheckBox Content="Send Seed" IsChecked="{Binding SendSwarmSeed}" Margin="0,0,12,0"/>
-                                <TextBlock Opacity="0.75" Text="Image Seed" VerticalAlignment="Center"/>
-                            </StackPanel>
-
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
-                                <CheckBox Content="Send LoRAs" IsChecked="{Binding SendSwarmLoras}" Margin="0,0,12,0"/>
-                                <TextBlock FontWeight="SemiBold" Text="LoRAs" VerticalAlignment="Center"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,6,0,8">
-                                <ComboBox MinWidth="300" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
-                                          ItemsSource="{Binding SwarmLoras}"
-                                          ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{Binding SwarmSelectedLora1, UpdateSourceTrigger=PropertyChanged}"/>
-                                <TextBlock Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" Text="Weight:"/>
-                                <TextBox Width="70" Margin="8,0,0,0" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
-                                         Text="{Binding SwarmLora1Weight, UpdateSourceTrigger=PropertyChanged}"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <ComboBox MinWidth="300" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
-                                          ItemsSource="{Binding SwarmLoras}"
-                                          ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{Binding SwarmSelectedLora2, UpdateSourceTrigger=PropertyChanged}"/>
-                                <TextBlock Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" Text="Weight:"/>
-                                <TextBox Width="70" Margin="8,0,0,0" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
-                                         Text="{Binding SwarmLora2Weight, UpdateSourceTrigger=PropertyChanged}"/>
-                            </StackPanel>
-
-                            <Button Width="150" Content="Refresh LoRAs" Command="{Binding RefreshSwarmLorasCommand}"/>
-                        </StackPanel>
-                    </Border>
-
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                        <Button Width="150" Margin="0,0,8,0" Content="Test Connection" Command="{Binding TestSwarmConnectionCommand}"/>
-                        <Button Width="150" Content="Open SwarmUI" Command="{Binding OpenSwarmUiCommand}"/>
-                    </StackPanel>
-
-                    <Border CornerRadius="10" Background="{StaticResource PanelBg}" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Padding="10">
-                        <TextBlock Text="{Binding SwarmUiStatusText}" TextWrapping="Wrap"/>
-                    </Border>
-                </StackPanel>
-            </ScrollViewer>
-        </Border>
-    </TabItem>
-    <TabItem Header="System">
-        <Border Padding="8" Background="Transparent">
-            <ListBox ItemsSource="{Binding ErrorEntries}" /></Border>
-    </TabItem>
-    <TabItem Header="File Editor">
-        <Border Padding="8" Background="Transparent">
-            <DockPanel>
-                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,8">
-                    <Button Content="Save" Width="90" Margin="0,0,8,0" Command="{Binding SaveEntryFileCommand}"/>
-                    <Button Content="Open" Width="90" Margin="0,0,8,0" Command="{Binding OpenEntryFileCommand}"/>
-                    <TextBlock Opacity="0.75" VerticalAlignment="Center" Text="{Binding EntryEditorPath}" TextTrimming="CharacterEllipsis"/>
-                </StackPanel>
-                <TextBox Text="{Binding EntryEditorText, UpdateSourceTrigger=PropertyChanged}"
-                         TextWrapping="Wrap" AcceptsReturn="True"
-                         VerticalScrollBarVisibility="Auto"
-                         Background="{StaticResource InputCyan}"
-                         FontSize="13"/>
-            </DockPanel>
-        </Border>
-    </TabItem>
-</TabControl>
-
-                        
-                    </Grid>
-                </Border>
-
-                </DockPanel>
+            <controls:PromptPanel Grid.Column="2"/>
 
 	        </Grid>
 
@@ -966,8 +606,8 @@
 	                                                                    Command="{Binding DataContext.SelectAllSubCategoriesCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}"><Path Style="{StaticResource IconPath}" Data="{StaticResource IcoSelectAll}"/></Button>
 														<Button Style="{StaticResource IconBtn}"  ToolTip="Select no subcategories"
 														        Command="{Binding DataContext.SelectNoneSubCategoriesCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}"><Path Style="{StaticResource IconPath}" Data="{StaticResource IcoSelectNone}"/></Button>
-														<ToggleButton Style="{StaticResource IconToggleBtn}" ToolTip="Lock category (exclude from randomization)" IsChecked="{Binding IsLocked}" Content="🔒"/>
-														<Button Style="{StaticResource IconBtn}" ToolTip="Randomize this category" Command="{Binding DataContext.RandomizeCategoryOnceCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" Content="🎲"/>
+														<ToggleButton Style="{StaticResource IconToggleBtn}" ToolTip="Lock category (exclude from randomization)" IsChecked="{Binding IsLocked}" Content="≡ƒöÆ"/>
+														<Button Style="{StaticResource IconBtn}" ToolTip="Randomize this category" Command="{Binding DataContext.RandomizeCategoryOnceCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" Content="≡ƒÄ▓"/>
 	</UniformGrid>
 	                                                    </DockPanel>
 	                                                    <Expander IsExpanded="{Binding IsExpanded, Mode=TwoWay}" Margin="0,8,0,0">
@@ -983,8 +623,8 @@
 	                                                                                        Command="{Binding DataContext.MoveSubCategoryUpCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}"><Path Style="{StaticResource IconPath}" Data="{StaticResource IcoChevronUp}"/></Button>
 																						<Button Style="{StaticResource IconBtn}"  ToolTip="Move subcategory down"
 																						        Command="{Binding DataContext.MoveSubCategoryDownCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}"><Path Style="{StaticResource IconPath}" Data="{StaticResource IcoChevronDown}"/></Button>
-																						<ToggleButton Style="{StaticResource IconToggleBtn}" ToolTip="Lock subcategory (exclude from randomization)" IsChecked="{Binding IsLocked}" Content="🔒"/>
-																						<Button Style="{StaticResource IconBtn}" ToolTip="Randomize this subcategory" Command="{Binding DataContext.RandomizeSubCategoryOnceCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" Content="🎲"/>
+																						<ToggleButton Style="{StaticResource IconToggleBtn}" ToolTip="Lock subcategory (exclude from randomization)" IsChecked="{Binding IsLocked}" Content="≡ƒöÆ"/>
+																						<Button Style="{StaticResource IconBtn}" ToolTip="Randomize this subcategory" Command="{Binding DataContext.RandomizeSubCategoryOnceCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" Content="≡ƒÄ▓"/>
 </UniformGrid>
 	                                                                            <Button CommandParameter="{Binding}" Command="{Binding DataContext.SelectSubCategoryCommand, RelativeSource={RelativeSource AncestorType=Window}}" Content="{Binding Name}" Background="Transparent" BorderThickness="0" Padding="6,2" HorizontalAlignment="Left"/></DockPanel>
 	                                                                    </DataTemplate>
@@ -1186,223 +826,13 @@
 	            </TabControl>
 
 	            <!-- Prompt (stacked bottom) -->
-	            <DockPanel Grid.Row="2">
-	                <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
-	                    <TextBlock FontSize="26" FontWeight="SemiBold" Text="Prompt" Foreground="{StaticResource AccentPink}"/>
-	                    <TextBlock Opacity="0.75" Text="Updates live. If empty, check System Messages."/>
-	                </StackPanel>
-	
-	                <Border Background="{StaticResource PanelBg}" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" CornerRadius="14" Padding="12" Margin="0,0,0,10">
-	                    <Grid>
-	                        <Grid.RowDefinitions>
-	                            <RowDefinition Height="Auto"/>
-	                            <RowDefinition Height="*"/>
-	                        </Grid.RowDefinitions>
-							<TabControl Grid.Row="1" Margin="0" Background="Transparent" VerticalAlignment="Stretch">
-    <TabItem Header="Prompt">
-        <Border Padding="8" Background="Transparent">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions><!-- Top controls -->
-<Grid Grid.Row="0" Margin="0,0,0,10">
-    <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="*"/>
-        <ColumnDefinition Width="Auto"/>
-    </Grid.ColumnDefinitions>
-
-    <WrapPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,12,0">
-        <Button Content="{Binding CopyButtonText}" Width="110" Margin="0,0,8,0" Command="{Binding CopyCommand}"/>
-        <Button Content="🎲 Randomize" Width="130" Margin="0,0,12,0" Command="{Binding RandomizeCommand}"/>
-        <Button Content="{Binding SwarmButtonText}" Width="160" Margin="0,0,12,0" Command="{Binding SendToSwarmUiCommand}"/>
-        <Button Content="Batch Generate" Width="140" Margin="0,0,0,0" Command="{Binding SendBatchToSwarmUiCommand}"/>
-    </WrapPanel>
-
-    <WrapPanel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Qty:"/>
-        <TextBox Width="52" Margin="8,0,12,0" Background="{StaticResource InputCyan}"
-                 HorizontalAlignment="Right"
-                 Text="{Binding BatchQty, UpdateSourceTrigger=PropertyChanged}"/>
-        <CheckBox Content="Randomize Prompts" VerticalAlignment="Center" IsChecked="{Binding BatchRandomizePrompts}" Margin="0,0,12,0"/>
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Prompt Seed:"/>
-        <TextBox Width="120" MinWidth="90" Margin="8,0,12,0" Background="{StaticResource InputCyan}"
-                 Text="{Binding PromptSeedText, UpdateSourceTrigger=PropertyChanged}" />
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Image Seed:"/>
-        <TextBox Width="120" MinWidth="90" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
-                 Text="{Binding ImageSeedText, UpdateSourceTrigger=PropertyChanged}" />
-    </WrapPanel>
-</Grid>
-
-            <controls:AutoSizeTextBox Grid.Row="1"
-                                     Background="{StaticResource PromptPink}"
-                                     FontSize="14"
-                                     MaxAutoHeight="260"
-                                     Text="{Binding PromptText, UpdateSourceTrigger=PropertyChanged}"/>
-
-                <Border Grid.Row="2" CornerRadius="12" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
-                        Background="{StaticResource PanelBg}" Padding="8" Margin="0,10,0,10">
-                    <DockPanel>
-                        <TextBlock DockPanel.Dock="Top" FontWeight="SemiBold" Text="Latest Images" Margin="0,0,0,6"/>
-                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                        <ItemsControl ItemsSource="{Binding RecentBatches}">
-                            <ItemsControl.Resources>
-                                <DataTemplate x:Key="ThumbTemplate">
-                                    <Border Width="160" Height="160" Margin="0,0,8,8" CornerRadius="10" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Background="#0A000000" Padding="6">
-                                        <Grid>
-                                            <Button Background="Transparent" BorderThickness="0" Padding="0"
-                                                    Command="{Binding DataContext.ShowImageOverlayCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                    CommandParameter="{Binding}">
-                                                <Image Source="{Binding Thumbnail}" Stretch="UniformToFill" />
-                                            </Button>
-                                            <Border Background="#99000000" CornerRadius="8" Padding="6"
-                                                    IsHitTestVisible="False"
-                                                    Visibility="{Binding IsGenerating, Converter={StaticResource BoolToVis}}">
-                                                <StackPanel VerticalAlignment="Bottom">
-                                                    <TextBlock Foreground="#FFF" FontSize="11" FontWeight="SemiBold"
-                                                               Text="{Binding Status}" TextTrimming="CharacterEllipsis"/>
-                                                    <TextBlock Foreground="#E6FFFFFF" FontSize="11" Margin="0,2,0,0"
-                                                               Text="{Binding StepProgressText}"
-                                                               Visibility="{Binding HasStepProgress, Converter={StaticResource BoolToVis}}"/>
-                                                    <ProgressBar Height="6" Margin="0,4,0,0" Minimum="0" Maximum="1"
-                                                                 Value="{Binding Progress}" IsIndeterminate="{Binding IsIndeterminate}"/>
-                                                </StackPanel>
-                                            </Border>
-                                        </Grid>
-                                    </Border>
-                                </DataTemplate>
-
-	                                <DataTemplate x:Key="BatchCardTemplate">
-	                                    <Border Margin="0,0,12,12" CornerRadius="12" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1" Background="#06000000" Padding="8" MinWidth="320">
-                                        <DockPanel>
-                                            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
-                                                <StackPanel Orientation="Horizontal">
-                                                    <TextBlock FontWeight="SemiBold" Text="{Binding Title, Converter={StaticResource OneLine}}"/>
-                                                    <TextBlock Opacity="0.65" Margin="10,0,0,0" Text="{Binding Items.Count, StringFormat=({0})}"/>
-                                                </StackPanel>
-                                                <TextBlock Opacity="0.78" FontSize="12" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
-                                                           Text="{Binding PromptSnippet, Converter={StaticResource OneLine}}"/>
-                                                <TextBlock Opacity="0.65" FontSize="12" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
-                                                           Text="{Binding SettingsSummary, Converter={StaticResource OneLine}}"/>
-                                            </StackPanel>
-
-                                            <ItemsControl ItemsSource="{Binding Items}" ItemTemplate="{StaticResource ThumbTemplate}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <WrapPanel Orientation="Horizontal"/>
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
-                                            </ItemsControl>
-                                        </DockPanel>
-                                    </Border>
-                                </DataTemplate>
-
-                                <DataTemplate x:Key="BatchSmallTemplate">
-                                    <Border Margin="0,0,12,12" Background="#03000000" BorderBrush="#22000000" BorderThickness="1" CornerRadius="10" Padding="6">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="32"/>
-                                                <ColumnDefinition Width="Auto"/>
-                                            </Grid.ColumnDefinitions>
-
-                                            <Border Grid.Column="0" Background="#0A000000" CornerRadius="8" Padding="2" Margin="0,0,6,8" VerticalAlignment="Stretch" MinHeight="160">
-                                                <TextBlock FontWeight="SemiBold" FontSize="11" Opacity="0.85" TextTrimming="CharacterEllipsis">
-                                                    <TextBlock.LayoutTransform>
-                                                        <RotateTransform Angle="-90"/>
-                                                    </TextBlock.LayoutTransform>
-                                                    <TextBlock.Text>
-                                                        <MultiBinding StringFormat="{}{0} · {1}">
-                                                            <Binding Path="Title" Converter="{StaticResource OneLine}"/>
-                                                            <Binding Path="PromptSnippet" Converter="{StaticResource OneLine}"/>
-                                                        </MultiBinding>
-                                                    </TextBlock.Text>
-                                                </TextBlock>
-                                            </Border>
-
-                                            <ItemsControl Grid.Column="1" ItemsSource="{Binding Items}" ItemTemplate="{StaticResource ThumbTemplate}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <WrapPanel Orientation="Horizontal"/>
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
-                                            </ItemsControl>
-                                        </Grid>
-                                    </Border>
-                                </DataTemplate>
-                            </ItemsControl.Resources>
-
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <WrapPanel Orientation="Horizontal"/>
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <ContentControl Content="{Binding}">
-                                        <ContentControl.Style>
-                                            <Style TargetType="ContentControl">
-                                                <Setter Property="ContentTemplate" Value="{StaticResource BatchSmallTemplate}"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsCard}" Value="True">
-                                                        <Setter Property="ContentTemplate" Value="{StaticResource BatchCardTemplate}"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </ContentControl.Style>
-                                    </ContentControl>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                        </ScrollViewer>
-                    </DockPanel>
-                </Border>
-
-                <Border Grid.Row="3" CornerRadius="8" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
-                        Background="{StaticResource PanelBg}" Padding="8">
-                    <DockPanel>
-                        <TextBlock DockPanel.Dock="Top" FontWeight="SemiBold" Text="Status" Margin="0,0,0,4"/>
-                        <TextBox Text="{Binding SystemMessages}" TextWrapping="Wrap" IsReadOnly="True"
-                                 BorderThickness="0" Background="Transparent" Height="54" VerticalScrollBarVisibility="Auto"/>
-                    </DockPanel>
-                </Border>
-            </Grid>
-        </Border>
-    </TabItem>
-    <TabItem Header="System">
-        <Border Padding="8" Background="Transparent">
-            <ListBox ItemsSource="{Binding ErrorEntries}" /></Border>
-    </TabItem>
-    <TabItem Header="File Editor">
-        <Border Padding="8" Background="Transparent">
-            <DockPanel>
-                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,8">
-                    <Button Content="Save" Width="90" Margin="0,0,8,0" Command="{Binding SaveEntryFileCommand}"/>
-                    <Button Content="Open" Width="90" Margin="0,0,8,0" Command="{Binding OpenEntryFileCommand}"/>
-                    <TextBlock Opacity="0.75" VerticalAlignment="Center" Text="{Binding EntryEditorPath}" TextTrimming="CharacterEllipsis"/>
-                </StackPanel>
-                <TextBox Text="{Binding EntryEditorText, UpdateSourceTrigger=PropertyChanged}"
-                         TextWrapping="Wrap" AcceptsReturn="True"
-                         VerticalScrollBarVisibility="Auto"
-                         Background="{StaticResource InputCyan}"
-                         FontSize="13"/>
-            </DockPanel>
-        </Border>
-    </TabItem>
-
-</TabControl>
-	                    </Grid>
-	                </Border>
-	
-	                </DockPanel>
+            <controls:PromptPanel Grid.Row="2"/>
 	        </Grid>
 
 	    </Grid>
 	</DockPanel>
 
-        <!-- Fullscreen image overlay: close via ✕ only; image supports zoom (wheel/up/down) + pan (drag) + prev/next (edges/left-right) -->
+        <!-- Fullscreen image overlay: close via Γ£ò only; image supports zoom (wheel/up/down) + pan (drag) + prev/next (edges/left-right) -->
 	        <Grid x:Name="ImageOverlayRoot" Panel.ZIndex="999"
               Background="#88000000"
 	              Visibility="{Binding IsImageOverlayVisible, Converter={StaticResource BoolToVis}}"
@@ -1422,7 +852,7 @@
 
                 <Button HorizontalAlignment="Right" VerticalAlignment="Top" Margin="12" Width="40" Height="40"
                         Background="#AA000000" Foreground="#FFF" BorderBrush="#33FFFFFF" BorderThickness="1"
-                        Content="✕" FontSize="16" FontWeight="SemiBold"
+                        Content="Γ£ò" FontSize="16" FontWeight="SemiBold"
                         Command="{Binding HideImageOverlayCommand}"/>
             </Grid>
 
@@ -1506,5 +936,6 @@
 
     </Grid>
 </Window>
+
 
 

--- a/PromptLoom.View/MainWindow.xaml
+++ b/PromptLoom.View/MainWindow.xaml
@@ -1,3 +1,7 @@
+<!-- CHANGE LOG -->
+<!-- - 2025-12-31 | Request: Single-image label sizing | Align small-batch labels with thumbnail height. -->
+<!-- - 2025-12-31 | Request: SwarmUI cards + toggles | Add model/LoRA cards and send toggles. -->
+<!-- - 2025-12-31 | Request: SwarmUI step progress | Overlay thumbnail cards with generation steps. -->
 <!-- Bugfix: Fix duplicate IconBtn resource key by renaming base style to IconBtnBase so style lookups are unambiguous. -->
 <!-- Bugfix: Allow the shared IconBtn style to apply to ToggleButton instances to prevent XamlParseException popups triggered by a Button-only style target. -->
 <Window x:Class="PromptLoom.MainWindow"
@@ -15,6 +19,18 @@
         <conv:PastelByIndexConverter x:Key="PastelByIndex"/>
         <conv:AspectToVisibilityConverter x:Key="AspectToVis"/>
         <conv:OneLineTextConverter x:Key="OneLine"/>
+
+        <DataTemplate x:Key="SwarmAssetCardTemplate">
+            <Border Background="#14000000" BorderBrush="{StaticResource BorderSoft}" BorderThickness="1"
+                    CornerRadius="8" Padding="6" Margin="0,2" ToolTip="{Binding Name}">
+                <StackPanel>
+                    <TextBlock FontWeight="SemiBold" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock FontSize="11" Opacity="0.65" Text="{Binding PathHint}" TextTrimming="CharacterEllipsis"
+                               Visibility="{Binding HasPathHint, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock FontSize="11" Opacity="0.7" Text="{Binding KindLabel}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
 
         
         <!-- Vector icons (24x24) -->
@@ -603,13 +619,12 @@
         <CheckBox Content="Randomize Prompts" VerticalAlignment="Center" IsChecked="{Binding BatchRandomizePrompts}" Margin="0,0,12,0"/>
 
 
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Seed:"/>
-
-
+        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Prompt Seed:"/>
+        <TextBox Width="120" MinWidth="90" Margin="8,0,12,0" Background="{StaticResource InputCyan}"
+                 Text="{Binding PromptSeedText, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Image Seed:"/>
         <TextBox Width="120" MinWidth="90" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
-
-
-                 Text="{Binding SeedText, UpdateSourceTrigger=PropertyChanged}" />
+                 Text="{Binding ImageSeedText, UpdateSourceTrigger=PropertyChanged}" />
 
 
     </WrapPanel>
@@ -639,6 +654,19 @@
                                                     CommandParameter="{Binding}">
                                                 <Image Source="{Binding Thumbnail}" Stretch="UniformToFill" />
                                             </Button>
+                                            <Border Background="#99000000" CornerRadius="8" Padding="6"
+                                                    IsHitTestVisible="False"
+                                                    Visibility="{Binding IsGenerating, Converter={StaticResource BoolToVis}}">
+                                                <StackPanel VerticalAlignment="Bottom">
+                                                    <TextBlock Foreground="#FFF" FontSize="11" FontWeight="SemiBold"
+                                                               Text="{Binding Status}" TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Foreground="#E6FFFFFF" FontSize="11" Margin="0,2,0,0"
+                                                               Text="{Binding StepProgressText}"
+                                                               Visibility="{Binding HasStepProgress, Converter={StaticResource BoolToVis}}"/>
+                                                    <ProgressBar Height="6" Margin="0,4,0,0" Minimum="0" Maximum="1"
+                                                                 Value="{Binding Progress}" IsIndeterminate="{Binding IsIndeterminate}"/>
+                                                </StackPanel>
+                                            </Border>
                                         </Grid>
                                     </Border>
                                 </DataTemplate>
@@ -681,7 +709,7 @@
                                             </Grid.ColumnDefinitions>
 
                                             <!-- Vertical label -->
-	                                            <Border Grid.Column="0" Background="#0A000000" CornerRadius="8" Padding="2" Margin="0,0,6,0" VerticalAlignment="Stretch" MinHeight="160">
+                                            <Border Grid.Column="0" Background="#0A000000" CornerRadius="8" Padding="2" Margin="0,0,6,8" VerticalAlignment="Stretch" MinHeight="160">
                                                 <TextBlock VerticalAlignment="Center" FontWeight="SemiBold" FontSize="11" Opacity="0.85" TextTrimming="CharacterEllipsis">
                                                     <TextBlock.LayoutTransform>
                                                         <RotateTransform Angle="-90"/>
@@ -774,7 +802,9 @@
                         <ComboBox MinWidth="360" Background="{StaticResource InputCyan}"
                                   IsEnabled="{Binding CanEditSwarmModelOverride}"
                                   ItemsSource="{Binding SwarmModels}"
-                                  SelectedItem="{Binding SwarmSelectedModel, UpdateSourceTrigger=PropertyChanged}"/>
+                                  ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
+                                  SelectedValuePath="Name"
+                                  SelectedValue="{Binding SwarmSelectedModel, UpdateSourceTrigger=PropertyChanged}"/>
                         <Button Width="150" Margin="8,0,0,0" Content="Refresh Models" Command="{Binding RefreshSwarmModelsCommand}"/>
                     </StackPanel>
 
@@ -798,6 +828,11 @@
                                          Text="{Binding SwarmCfgScale, UpdateSourceTrigger=PropertyChanged}"/>
                             </StackPanel>
 
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                <CheckBox Content="Send Seed" IsChecked="{Binding SendSwarmSeed}" Margin="0,0,12,0"/>
+                                <TextBlock Opacity="0.75" Text="Image Seed" VerticalAlignment="Center"/>
+                            </StackPanel>
+
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
                                 <CheckBox Content="Send LoRAs" IsChecked="{Binding SendSwarmLoras}" Margin="0,0,12,0"/>
                                 <TextBlock FontWeight="SemiBold" Text="LoRAs" VerticalAlignment="Center"/>
@@ -805,7 +840,9 @@
                             <StackPanel Orientation="Horizontal" Margin="0,6,0,8">
                                 <ComboBox MinWidth="300" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
                                           ItemsSource="{Binding SwarmLoras}"
-                                          SelectedItem="{Binding SwarmSelectedLora1, UpdateSourceTrigger=PropertyChanged}"/>
+                                          ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{Binding SwarmSelectedLora1, UpdateSourceTrigger=PropertyChanged}"/>
                                 <TextBlock Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" Text="Weight:"/>
                                 <TextBox Width="70" Margin="8,0,0,0" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
                                          Text="{Binding SwarmLora1Weight, UpdateSourceTrigger=PropertyChanged}"/>
@@ -813,7 +850,9 @@
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                                 <ComboBox MinWidth="300" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
                                           ItemsSource="{Binding SwarmLoras}"
-                                          SelectedItem="{Binding SwarmSelectedLora2, UpdateSourceTrigger=PropertyChanged}"/>
+                                          ItemTemplate="{StaticResource SwarmAssetCardTemplate}"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{Binding SwarmSelectedLora2, UpdateSourceTrigger=PropertyChanged}"/>
                                 <TextBlock Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" Text="Weight:"/>
                                 <TextBox Width="70" Margin="8,0,0,0" Background="{StaticResource InputCyan}" IsEnabled="{Binding CanEditSwarmLoras}"
                                          Text="{Binding SwarmLora2Weight, UpdateSourceTrigger=PropertyChanged}"/>
@@ -1188,9 +1227,12 @@
                  HorizontalAlignment="Right"
                  Text="{Binding BatchQty, UpdateSourceTrigger=PropertyChanged}"/>
         <CheckBox Content="Randomize Prompts" VerticalAlignment="Center" IsChecked="{Binding BatchRandomizePrompts}" Margin="0,0,12,0"/>
-        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Seed:"/>
+        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Prompt Seed:"/>
+        <TextBox Width="120" MinWidth="90" Margin="8,0,12,0" Background="{StaticResource InputCyan}"
+                 Text="{Binding PromptSeedText, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBlock Margin="0,4,0,0" Opacity="0.75" Text="Image Seed:"/>
         <TextBox Width="120" MinWidth="90" Margin="8,0,0,0" Background="{StaticResource InputCyan}"
-                 Text="{Binding SeedText, UpdateSourceTrigger=PropertyChanged}" />
+                 Text="{Binding ImageSeedText, UpdateSourceTrigger=PropertyChanged}" />
     </WrapPanel>
 </Grid>
 
@@ -1215,6 +1257,19 @@
                                                     CommandParameter="{Binding}">
                                                 <Image Source="{Binding Thumbnail}" Stretch="UniformToFill" />
                                             </Button>
+                                            <Border Background="#99000000" CornerRadius="8" Padding="6"
+                                                    IsHitTestVisible="False"
+                                                    Visibility="{Binding IsGenerating, Converter={StaticResource BoolToVis}}">
+                                                <StackPanel VerticalAlignment="Bottom">
+                                                    <TextBlock Foreground="#FFF" FontSize="11" FontWeight="SemiBold"
+                                                               Text="{Binding Status}" TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Foreground="#E6FFFFFF" FontSize="11" Margin="0,2,0,0"
+                                                               Text="{Binding StepProgressText}"
+                                                               Visibility="{Binding HasStepProgress, Converter={StaticResource BoolToVis}}"/>
+                                                    <ProgressBar Height="6" Margin="0,4,0,0" Minimum="0" Maximum="1"
+                                                                 Value="{Binding Progress}" IsIndeterminate="{Binding IsIndeterminate}"/>
+                                                </StackPanel>
+                                            </Border>
                                         </Grid>
                                     </Border>
                                 </DataTemplate>
@@ -1252,7 +1307,7 @@
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
 
-	                                            <Border Grid.Column="0" Background="#0A000000" CornerRadius="8" Padding="2" Margin="0,0,6,0" VerticalAlignment="Stretch" MinHeight="160">
+                                            <Border Grid.Column="0" Background="#0A000000" CornerRadius="8" Padding="2" Margin="0,0,6,8" VerticalAlignment="Stretch" MinHeight="160">
                                                 <TextBlock FontWeight="SemiBold" FontSize="11" Opacity="0.85" TextTrimming="CharacterEllipsis">
                                                     <TextBlock.LayoutTransform>
                                                         <RotateTransform Angle="-90"/>
@@ -1451,3 +1506,5 @@
 
     </Grid>
 </Window>
+
+

--- a/PromptLoom.ViewModel/ViewModels/MainViewModel.cs
+++ b/PromptLoom.ViewModel/ViewModels/MainViewModel.cs
@@ -1,7 +1,7 @@
 // CHANGE LOG
 // - 2026-03-02 | Fix: Restore AutoSave helper | Reintroduce AutoSave to funnel into the debounced queue.
-// - 2025-12-31 | Request: MVVM split | Update project root sentinel to PromptLoom.View.csproj.
-// - 2025-12-25 | Fix: UI side-effect wrappers | Inject UI service wrappers for testable side effects.
+// - 2025-12-31 | Request: SwarmUI cards + toggles | Add model/LoRA cards, seed toggle, and persistence fixes.
+// - 2025-12-31 | Request: SwarmUI progress + seed split | Track steps per image and separate prompt/image seeds.
 // FIX: Introduce UI side-effect wrappers for MessageBox/Clipboard/Process/Dispatcher to improve testability.
 // CAUSE: Direct static UI calls in the view model required WPF runtime in tests.
 // CHANGE: Inject UI service wrappers and use them for side effects. 2025-12-25
@@ -151,12 +151,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public string SwarmSelectedModel
     {
         get => _swarmSelectedModel;
-        set { _swarmSelectedModel = value; OnPropertyChanged(); }
+        set { _swarmSelectedModel = value; OnPropertyChanged(); QueueAutoSave(); }
     }
 
-    public ObservableCollection<string> SwarmModels { get; } = new();
+    public ObservableCollection<SwarmAssetCardViewModel> SwarmModels { get; } = new();
 
-    public ObservableCollection<string> SwarmLoras { get; } = new();
+    public ObservableCollection<SwarmAssetCardViewModel> SwarmLoras { get; } = new();
 
     private bool _sendSwarmModelOverride = true;
     public bool SendSwarmModelOverride
@@ -178,7 +178,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public bool SendSwarmCfgScale
     {
         get => _sendSwarmCfgScale;
-        set { _sendSwarmCfgScale = value; OnPropertyChanged(); OnPropertyChanged(nameof(CanEditSwarmCfgScale)); }
+        set { _sendSwarmCfgScale = value; OnPropertyChanged(); QueueAutoSave(); OnPropertyChanged(nameof(CanEditSwarmCfgScale)); }
     }
     public bool CanEditSwarmCfgScale => SendSwarmCfgScale;
 
@@ -194,6 +194,13 @@ public sealed class MainViewModel : INotifyPropertyChanged
     {
         get => _swarmCfgScale;
         set { _swarmCfgScale = Math.Max(0.0, value); OnPropertyChanged(); QueueAutoSave(); }
+    }
+
+    private bool _sendSwarmSeed = true;
+    public bool SendSwarmSeed
+    {
+        get => _sendSwarmSeed;
+        set { _sendSwarmSeed = value; OnPropertyChanged(); QueueAutoSave(); }
     }
 
     private bool _sendSwarmLoras = false;
@@ -215,7 +222,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public string SwarmSelectedLora2
     {
         get => _swarmSelectedLora2;
-        set { _swarmSelectedLora2 = value; OnPropertyChanged(); }
+        set { _swarmSelectedLora2 = value; OnPropertyChanged(); QueueAutoSave(); }
     }
 
     private double _swarmLora1Weight = 1.0;
@@ -452,36 +459,30 @@ public sealed class MainViewModel : INotifyPropertyChanged
 private string _promptText = "";
     public string PromptText { get => _promptText; set { _promptText = value; OnPropertyChanged(); } }
 
-    private string _seedText = "";
-    // NOTE (2025-12-25): SeedText is user-editable and normally triggers prompt recomputation.
-    // SwarmUI can also report back the *actual* seed used for a generation; updating the seed display
-    // should not mutate the prompt currently shown in the prompt box. We therefore support a
-    // suppression mode for programmatic updates coming from SwarmUI frames.
-    public string SeedText
+    private string _promptSeedText = "";
+    // NOTE (2025-12-25): PromptSeedText is user-editable and triggers prompt recomputation.
+    public string PromptSeedText
     {
-        get => _seedText;
+        get => _promptSeedText;
         set
         {
-            _seedText = value;
+            _promptSeedText = value;
             OnPropertyChanged();
-            if (!_suppressSeedDrivenPromptRecompute)
-                RecomputePrompt();
+            RecomputePrompt();
         }
     }
 
-    private bool _suppressSeedDrivenPromptRecompute;
-
-    private void SetSeedTextFromSwarm(long seed)
+    private string _imageSeedText = "";
+    // NOTE (2025-12-31): ImageSeedText is used only for SwarmUI image generation.
+    public string ImageSeedText
     {
-        _suppressSeedDrivenPromptRecompute = true;
-        try
-        {
-            SeedText = seed.ToString(CultureInfo.InvariantCulture);
-        }
-        finally
-        {
-            _suppressSeedDrivenPromptRecompute = false;
-        }
+        get => _imageSeedText;
+        set { _imageSeedText = value; OnPropertyChanged(); }
+    }
+
+    private void SetImageSeedTextFromSwarm(long seed)
+    {
+        ImageSeedText = seed.ToString(CultureInfo.InvariantCulture);
     }
 
     // (UI) Copy feedback is shown directly on the Copy button.
@@ -1075,6 +1076,8 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
             SendSwarmCfgScale = s.SendSwarmCfgScale;
             SwarmCfgScale = s.SwarmCfgScale;
 
+            SendSwarmSeed = s.SendSwarmSeed;
+
             SendSwarmModelOverride = s.SendSwarmModelOverride;
             SwarmSelectedModel = s.SwarmSelectedModel ?? "";
 
@@ -1107,6 +1110,8 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
 
                 SendSwarmCfgScale = SendSwarmCfgScale,
                 SwarmCfgScale = SwarmCfgScale,
+
+                SendSwarmSeed = SendSwarmSeed,
 
                 SendSwarmModelOverride = SendSwarmModelOverride,
                 SwarmSelectedModel = SwarmSelectedModel,
@@ -1148,7 +1153,7 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
         {
             // NOTE (2025-12-22): SwarmUI accepts seed values of -1 (random) or any non-negative number.
             // Other negative numbers cause SwarmUI to error, so we clamp them to -1.
-            var seedLong = seedOverride.HasValue ? seedOverride.Value : NormalizeSeedForSwarmUi(SeedText);
+            var seedLong = seedOverride.HasValue ? seedOverride.Value : NormalizeSeedForSwarmUi(PromptSeedText);
             int? seed = seedLong is null
                 ? null
                 : (seedLong.Value <= int.MaxValue ? (int)seedLong.Value : int.MaxValue);
@@ -1197,7 +1202,7 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
     private void SendToSwarmUi()
     {
         if (string.IsNullOrWhiteSpace(PromptText)) return;
-        var seed = NormalizeSeedForSwarmUi(SeedText);
+        var seed = SendSwarmSeed ? NormalizeSeedForSwarmUi(ImageSeedText) : null;
         var batch = CreateBatchForRun(title: "Single", promptSnapshot: PromptText, seed: seed);
         _dispatcher.Invoke(() => AddRecentBatch(batch));
         _ = StartSwarmGenerationAsync(batch, PromptText, seed);
@@ -1207,21 +1212,21 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
     {
         // Fire off multiple generations grouped into a single batch.
         // "Randomized prompts" here means: regenerate the PromptLoom prompt using a fresh seed each time.
-        var batch = CreateBatchForRun(title: $"Batch ×{BatchQty}", promptSnapshot: PromptText, seed: null);
+        var imageSeed = SendSwarmSeed ? NormalizeSeedForSwarmUi(ImageSeedText) : null;
+        var batch = CreateBatchForRun(title: $"Batch ×{BatchQty}", promptSnapshot: PromptText, seed: imageSeed);
         _dispatcher.Invoke(() => AddRecentBatch(batch));
 
         for (var i = 0; i < BatchQty; i++)
         {
             string prompt;
-            long? seed;
+            long? seed = imageSeed;
 
             if (BatchRandomizePrompts)
             {
-                var s = _random.Next(0, int.MaxValue);
-                seed = s;
+                var promptSeed = _random.Next(0, int.MaxValue);
                 try
                 {
-                    var res = _engine.Generate(Categories, s);
+                    var res = _engine.Generate(Categories, promptSeed);
                     prompt = res.Prompt;
                 }
                 catch
@@ -1233,7 +1238,6 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
             else
             {
                 prompt = PromptText;
-                seed = NormalizeSeedForSwarmUi(SeedText);
             }
 
             if (string.IsNullOrWhiteSpace(prompt)) continue;
@@ -1373,7 +1377,7 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
             {
                 if (cts.IsCancellationRequested) break;
 
-                if (SwarmWsParser.TryParseSwarmWsFrame(frame, out var status, out var progress01, out var previewDataUrl, out var finalImageRef, out var seedUsed))
+                if (SwarmWsParser.TryParseSwarmWsFrame(frame, out var status, out var progress01, out var step, out var steps, out var previewDataUrl, out var finalImageRef, out var seedUsed))
                 {
                     _dispatcher.Invoke(() =>
                     {
@@ -1382,10 +1386,16 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
                         if (!string.IsNullOrWhiteSpace(status))
                             item.Status = status;
 
+                        if (step is not null || steps is not null)
+                        {
+                            item.CurrentStep = step;
+                            item.TotalSteps = steps;
+                        }
+
                         if (seedUsed is not null)
                         {
                             // Keep the Prompt tab's seed display in sync with the actual SwarmUI seed.
-                            SetSeedTextFromSwarm(seedUsed.Value);
+                            SetImageSeedTextFromSwarm(seedUsed.Value);
                             item.Seed = seedUsed.Value;
                         }
 
@@ -1586,11 +1596,11 @@ private static async Task<ImageSource?> TryDownloadSwarmImageAsync(Uri baseUri, 
 
     private void Randomize()
     {
-        // Generate a new random seed and trigger prompt recomputation. Setting the seed
+        // Generate a new random seed and trigger prompt recomputation. Setting the prompt seed
         // property will cause RecomputePrompt() via its setter.
         // NOTE (2025-12-22): SwarmUI rejects negative seeds other than -1.
         // Keep randomized seeds non-negative so they are always valid for both PromptLoom and SwarmUI.
-        SeedText = _random.Next(0, int.MaxValue).ToString();
+        PromptSeedText = _random.Next(0, int.MaxValue).ToString();
         // When prefixes/suffixes are changed after randomization, recompute prompt using new random seed.
         QueueRecomputePrompt(immediate: true);
     }
@@ -1618,6 +1628,9 @@ private static async Task<ImageSource?> TryDownloadSwarmImageAsync(Uri baseUri, 
         }
     }
 
+    private static SwarmAssetCardViewModel BuildSwarmCard(string name, string kindLabel)
+        => new SwarmAssetCardViewModel(name, kindLabel);
+
     internal async Task RefreshSwarmModels()
     {
         try
@@ -1625,20 +1638,22 @@ private static async Task<ImageSource?> TryDownloadSwarmImageAsync(Uri baseUri, 
             SwarmUiStatusText = "Loading models...";
 
             var models = await _swarmService.ListModelsAsync(SwarmUrl, SwarmToken, depth: 8, ct: CancellationToken.None).ConfigureAwait(false);
+            var cards = models.Select(m => BuildSwarmCard(m, "Model")).ToList();
 
             _dispatcher.Invoke(() =>
             {
                 SwarmModels.Clear();
-                foreach (var m in models)
-                    SwarmModels.Add(m);
+                foreach (var card in cards)
+                    SwarmModels.Add(card);
 
-                if (!string.IsNullOrWhiteSpace(SwarmSelectedModel) && SwarmModels.Contains(SwarmSelectedModel))
+                if (!string.IsNullOrWhiteSpace(SwarmSelectedModel) &&
+                    SwarmModels.Any(m => string.Equals(m.Name, SwarmSelectedModel, StringComparison.OrdinalIgnoreCase)))
                 {
                     // keep user's selection
                 }
                 else if (SwarmModels.Count > 0)
                 {
-                    SwarmSelectedModel = SwarmModels[0];
+                    SwarmSelectedModel = SwarmModels[0].Name;
                 }
 
                 SwarmUiStatusText = models.Count == 0
@@ -1660,12 +1675,33 @@ private static async Task<ImageSource?> TryDownloadSwarmImageAsync(Uri baseUri, 
             SwarmUiStatusText = "Loading LoRAs...";
 
             var loras = await _swarmService.ListLorasAsync(SwarmUrl, SwarmToken, depth: 8, ct: CancellationToken.None).ConfigureAwait(false);
+            var cards = loras.Select(l => BuildSwarmCard(l, "LoRA")).ToList();
 
             _dispatcher.Invoke(() =>
             {
                 SwarmLoras.Clear();
-                foreach (var l in loras)
-                    SwarmLoras.Add(l);
+                foreach (var card in cards)
+                    SwarmLoras.Add(card);
+
+                if (!string.IsNullOrWhiteSpace(SwarmSelectedLora1) &&
+                    SwarmLoras.Any(l => string.Equals(l.Name, SwarmSelectedLora1, StringComparison.OrdinalIgnoreCase)))
+                {
+                    // keep selection
+                }
+                else if (SwarmLoras.Count > 0)
+                {
+                    SwarmSelectedLora1 = SwarmLoras[0].Name;
+                }
+
+                if (!string.IsNullOrWhiteSpace(SwarmSelectedLora2) &&
+                    SwarmLoras.Any(l => string.Equals(l.Name, SwarmSelectedLora2, StringComparison.OrdinalIgnoreCase)))
+                {
+                    // keep selection
+                }
+                else
+                {
+                    SwarmSelectedLora2 = "";
+                }
 
                 SwarmUiStatusText = loras.Count == 0
                     ? "Connected, but no LoRAs were returned (none installed or backend still loading?)."

--- a/PromptLoom.ViewModel/ViewModels/MainViewModel.cs
+++ b/PromptLoom.ViewModel/ViewModels/MainViewModel.cs
@@ -1,7 +1,7 @@
 // CHANGE LOG
+// - 2026-03-02 | Request: Batch qty slider | Clamp batch quantity to 2-50.
 // - 2026-03-02 | Fix: Restore AutoSave helper | Reintroduce AutoSave to funnel into the debounced queue.
 // - 2025-12-31 | Request: SwarmUI cards + toggles | Add model/LoRA cards, seed toggle, and persistence fixes.
-// - 2025-12-31 | Request: SwarmUI progress + seed split | Track steps per image and separate prompt/image seeds.
 // FIX: Introduce UI side-effect wrappers for MessageBox/Clipboard/Process/Dispatcher to improve testability.
 // CAUSE: Direct static UI calls in the view model required WPF runtime in tests.
 // CHANGE: Inject UI service wrappers and use them for side effects. 2025-12-25
@@ -243,7 +243,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public int BatchQty
     {
         get => _batchQty;
-        set { _batchQty = Math.Clamp(value, 1, 999); OnPropertyChanged(); QueueAutoSave(); }
+        set { _batchQty = Math.Clamp(value, 2, 50); OnPropertyChanged(); QueueAutoSave(); }
     }
 
     private bool _batchRandomizePrompts = true;
@@ -1087,7 +1087,7 @@ private void OnSubCategoryPropertyChanged(object? sender, PropertyChangedEventAr
             SwarmSelectedLora2 = s.SwarmSelectedLora2 ?? "";
             SwarmLora2Weight = s.SwarmLora2Weight;
 
-            BatchQty = Math.Max(1, s.BatchQty);
+            BatchQty = Math.Clamp(s.BatchQty, 2, 50);
             BatchRandomizePrompts = s.BatchRandomizePrompts;
         }
         catch (Exception ex)

--- a/PromptLoom.ViewModel/ViewModels/RecentSwarmImageViewModel.cs
+++ b/PromptLoom.ViewModel/ViewModels/RecentSwarmImageViewModel.cs
@@ -1,3 +1,7 @@
+// CHANGE LOG
+// - 2025-12-31 | Request: Show step progress | Add per-image step/total step tracking for cards.
+// - 2025-12-22 | Fix: Per-image SwarmUI progress | Add status/progress/cancel fields per thumbnail.
+// - 2025-12-22 | Fix: Move SwarmUI generation UI | Replace global status bar with per-item view model.
 /*
 FIX: Move SwarmUI generation status/progress/cancel UI into each thumbnail item instead of global bar.
 CAUSE: Global status couldn't represent concurrent/overlapping generations and forced HttpClient timeout hacks.
@@ -44,6 +48,35 @@ public sealed class RecentSwarmImageViewModel : INotifyPropertyChanged
     /// <summary>0..1</summary>
     public double Progress { get => _progress; set { _progress = value; OnPropertyChanged(); OnPropertyChanged(nameof(ProgressPercent)); } }
     public int ProgressPercent => (int)Math.Round(Math.Clamp(Progress, 0, 1) * 100);
+
+    private int? _currentStep;
+    public int? CurrentStep
+    {
+        get => _currentStep;
+        set
+        {
+            _currentStep = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasStepProgress));
+            OnPropertyChanged(nameof(StepProgressText));
+        }
+    }
+
+    private int? _totalSteps;
+    public int? TotalSteps
+    {
+        get => _totalSteps;
+        set
+        {
+            _totalSteps = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasStepProgress));
+            OnPropertyChanged(nameof(StepProgressText));
+        }
+    }
+
+    public bool HasStepProgress => CurrentStep.HasValue && TotalSteps.HasValue && TotalSteps.Value > 0;
+    public string StepProgressText => HasStepProgress ? $"Step {CurrentStep}/{TotalSteps}" : "";
 
     private bool _isIndeterminate = true;
     public bool IsIndeterminate { get => _isIndeterminate; set { _isIndeterminate = value; OnPropertyChanged(); } }

--- a/PromptLoom.ViewModel/ViewModels/SwarmAssetCardViewModel.cs
+++ b/PromptLoom.ViewModel/ViewModels/SwarmAssetCardViewModel.cs
@@ -1,0 +1,36 @@
+// CHANGE LOG
+// - 2025-12-31 | Request: Model/LoRA cards | Provide card metadata for SwarmUI dropdowns.
+using System;
+using System.IO;
+
+namespace PromptLoom.ViewModels;
+
+/// <summary>
+/// Presentation data for a SwarmUI model or LoRA selection card.
+/// </summary>
+public sealed class SwarmAssetCardViewModel
+{
+    /// <summary>
+    /// Creates a new card for the given asset name and kind.
+    /// </summary>
+    public SwarmAssetCardViewModel(string name, string kindLabel)
+    {
+        Name = name ?? string.Empty;
+        KindLabel = kindLabel ?? string.Empty;
+
+        var normalized = Name.Replace('/', Path.DirectorySeparatorChar);
+        var fileName = Path.GetFileName(normalized);
+        DisplayName = string.IsNullOrWhiteSpace(fileName)
+            ? Name
+            : Path.GetFileNameWithoutExtension(fileName);
+
+        var dir = Path.GetDirectoryName(normalized) ?? string.Empty;
+        PathHint = string.IsNullOrWhiteSpace(dir) ? string.Empty : dir.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    public string Name { get; }
+    public string DisplayName { get; }
+    public string KindLabel { get; }
+    public string PathHint { get; }
+    public bool HasPathHint => !string.IsNullOrWhiteSpace(PathHint);
+}


### PR DESCRIPTION
## Summary
- Replace duplicated prompt settings block with shared PromptPanel control.
- Polish prompt layout: centered action buttons, batch/seeds alignment, qty slider and live label, dice icon for randomize, and tidy seed rows.
- Clamp and default BatchQty to 2..50.

## Testing
- dotnet build .
- dotnet test .

## Version
- BaseVersion 2.1.1 (patch)
